### PR TITLE
Refactor mechanisms to use shared execution context

### DIFF
--- a/Assets/Scripts/BasicMoves/MeleeInstantMechanic.cs
+++ b/Assets/Scripts/BasicMoves/MeleeInstantMechanic.cs
@@ -5,19 +5,24 @@ using UnityEngine;
 [CreateAssetMenu(menuName = "Mechanics/Melee Instant")]
 public class MeleeInstantMechanic : SkillMechanismBase<MeleeParams>
 {
-    public override IEnumerator Cast(Transform owner, Camera cam, MeleeParams p)
+    protected override IEnumerator Execute(MechanismContext ctx, MeleeParams p)
     {
-        Debug.Log("Melee Instant Skill Casted");
+        var owner = ctx.Owner;
+        if (!owner)
+        {
+            Debug.LogWarning("[MeleeInstantMechanic] Owner transformÍ∞Ä Ï°¥Ïû¨ÌïòÏßÄ ÏïäÏäµÎãàÎã§.");
+            yield break;
+        }
+
         if (p.windup > 0f) yield return new WaitForSeconds(p.windup);
 
         Vector2 origin = owner.position;
-        Vector2 fwd = GetMouseDir(cam, origin);
+        Vector2 fwd = GetAimDir(ctx.Camera, origin);
         float half = p.angleDeg * 0.5f;
 
         var hits = Physics2D.OverlapCircleAll(origin, p.radius, p.enemyMask);
         foreach (var c in hits)
         {
-            // ∞¢µµ « ≈Õ(360¿Ã∏È Ω∫≈µ)
             if (p.angleDeg < 359f)
             {
                 Vector2 to = (Vector2)c.bounds.ClosestPoint(origin) - origin;
@@ -29,7 +34,10 @@ public class MeleeInstantMechanic : SkillMechanismBase<MeleeParams>
             }
 
             if (c.TryGetComponent(out ActInterfaces.IVulnerable v))
+            {
                 v.TakeDamage(p.attack * p.attackPercent, p.apRatio);
+                ctx.EmitHook(AbilityHook.OnHit, c.transform, c.bounds.ClosestPoint(origin), nameof(MeleeInstantMechanic));
+            }
 
             if (c.attachedRigidbody)
             {
@@ -39,12 +47,16 @@ public class MeleeInstantMechanic : SkillMechanismBase<MeleeParams>
         }
 
         if (p.recover > 0f) yield return new WaitForSeconds(p.recover);
+
+        ctx.EmitHook(AbilityHook.OnCastEnd, null, origin, nameof(MeleeInstantMechanic));
     }
 
-    static Vector2 GetMouseDir(Camera cam, Vector2 from)
+    static Vector2 GetAimDir(Camera cam, Vector2 from)
     {
         if (!cam) return Vector2.right;
         var m = cam.ScreenToWorldPoint(Input.mousePosition);
-        m.z = 0f; return ((Vector2)m - from).normalized;
+        m.z = 0f;
+        Vector2 dir = ((Vector2)m - from);
+        return dir.sqrMagnitude < 1e-6f ? Vector2.right : dir.normalized;
     }
 }

--- a/Assets/Scripts/BasicMoves/MoveParams.cs
+++ b/Assets/Scripts/BasicMoves/MoveParams.cs
@@ -1,4 +1,4 @@
-﻿// MoveParams.cs (REFACTOR/EXTEND)
+// MoveParams.cs (REFACTOR/EXTEND)
 using System.Collections.Generic;
 using UnityEngine;
 using SkillInterfaces;
@@ -19,36 +19,23 @@ public class MeleeParams : ISkillParam, IHasCooldown, IFollowUpProvider
     public float windup = 0.05f, recover = 0.08f, cooldown = 0.10f;
     public float Cooldown => cooldown;
 
-    // ★ FollowUp(예: 2타)을 Param에 직접 둠 — 필요 시 인스펙터에서 설정
     public List<MechanicRef> onHit = new();
     public List<MechanicRef> onExpire = new();
-	public IEnumerable<(CastOrder, float, bool)> BuildFollowUps(AbilityHook hook, Transform prevTarget)
-	{
-		if (hook != AbilityHook.OnCastEnd || onExpire == null) yield break;
-		foreach (var m in onExpire)
-		{
-			Debug.Log(m);
-			if (m.TryBuildOrder(null, out var order))
-			{
-				Debug.Log($"Callback {order.Mech}!");
-				yield return (order, m.delay, m.respectBusyCooldown);
-			}
-			else
-			{
-				Debug.Log("No callback...");
-				yield break;
-			}
-		}
-	}
-	/*public IEnumerable<(CastOrder, float, bool)> BuildFollowUps(AbilityHook hook, Transform prevTarget)
+
+    public IEnumerable<(CastOrder, float, bool)> BuildFollowUps(AbilityHook hook, Transform prevTarget)
     {
-        var src = hook == AbilityHook.OnHit ? onHit :
-                    hook == AbilityHook.OnExpire ? onExpire : null;
+        var src = hook switch
+        {
+            AbilityHook.OnHit => onHit,
+            AbilityHook.OnCastEnd => onExpire,
+            _ => null
+        };
         if (src == null) yield break;
+
         foreach (var mref in src)
             if (mref.TryBuildOrder(prevTarget, out var order))
                 yield return (order, mref.delay, mref.respectBusyCooldown);
-    }*/
+    }
 }
 
 [System.Serializable]
@@ -76,43 +63,42 @@ public class MissileParams : ISkillParam, IHasCooldown, IFollowUpProvider, ITarg
     [Header("Behavior")]
     public bool retargetOnLost = true;
     public float retargetRadius = 3f;
+
     [Header("Targeter")]
-    public TargetMode mode; public float fallback = 10f; public Vector2 local; public float col; public float skin; public bool canpen;
-    public TargetMode Mode => mode; public float FallbackRange => fallback; public Vector2 LocalOffset => local; public LayerMask WallsMask => blockerMask;
-    public float CollisionRadius => col; public float AnchorSkin => skin; public bool CanPenetrate => canpen;
+    public TargetMode mode;
+    public float fallback = 10f;
+    public Vector2 local;
+    public float col;
+    public float skin;
+    public bool canpen;
 
+    public TargetMode Mode => mode;
+    public float FallbackRange => fallback;
+    public Vector2 LocalOffset => local;
+    public LayerMask WallsMask => blockerMask;
+    public float CollisionRadius => col;
+    public float AnchorSkin => skin;
+    public bool CanPenetrate => canpen;
 
-    // ★ FollowUp 예: 맞으면 폭발, 소멸하면 잔류 디버프…
     public List<MechanicRef> onHit = new();
     public List<MechanicRef> onExpire = new();
-	public IEnumerable<(CastOrder, float, bool)> BuildFollowUps(AbilityHook hook, Transform prevTarget)
-	{
-		if (hook != AbilityHook.OnCastEnd || onExpire == null) yield break;
-		foreach (var m in onExpire)
-		{
-			Debug.Log(m);
-			if (m.TryBuildOrder(null, out var order))
-			{
-				Debug.Log($"Callback {order.Mech}!");
-				yield return (order, m.delay, m.respectBusyCooldown);
-			}
-			else
-			{
-				Debug.Log("No callback...");
-				yield break;
-			}
-		}
-	}
-	/*public IEnumerable<(CastOrder, float, bool)> BuildFollowUps(AbilityHook hook, Transform prevTarget)
+
+    public IEnumerable<(CastOrder, float, bool)> BuildFollowUps(AbilityHook hook, Transform prevTarget)
     {
-        var src = hook == AbilityHook.OnHit ? onHit :
-                    hook == AbilityHook.OnExpire ? onExpire : null;
+        var src = hook switch
+        {
+            AbilityHook.OnHit => onHit,
+            AbilityHook.OnCastEnd => onExpire,
+            _ => null
+        };
         if (src == null) yield break;
+
         foreach (var mref in src)
             if (mref.TryBuildOrder(prevTarget, out var order))
                 yield return (order, mref.delay, mref.respectBusyCooldown);
-    }*/
+    }
 }
+
 [System.Serializable]
 public class DashParams : ISkillParam, IHasCooldown, IFollowUpProvider, ITargetingData, IAnchorClearance
 {
@@ -130,21 +116,20 @@ public class DashParams : ISkillParam, IHasCooldown, IFollowUpProvider, ITargeti
     public bool CanPenetrate => _canpen;
 
     [Header("Motion")]
-    public float duration = 0.18f;           // 총 대시 시간
+    public float duration = 0.18f;
     public AnimationCurve speedCurve = AnimationCurve.Linear(0, 1, 1, 1);
-    public bool stopOnWall = true;           // 벽 충돌 시 즉시 종료
+    public bool stopOnWall = true;
 
     [Header("Collision Volume")]
-    public float radius = 0.5f;              // 내 몸의 반경(적/벽 체크 모두에 사용)
-    public float skin = 0.05f;               // 충돌면 살짝 넘기는 여유
+    public float radius = 0.5f;
+    public float skin = 0.05f;
 
-    // IAnchorClearance
     public float CollisionRadius => radius;
     public float AnchorSkin => Mathf.Max(0.01f, skin);
 
     [Header("Combat During Dash")]
-    public bool dealDamage = true;           // 대시 중 피해를 줄 것인지
-    public bool canPenetrate = true;         // 적을 관통할지
+    public bool dealDamage = true;
+    public bool canPenetrate = true;
     public LayerMask enemyMask;
     public float damage = 8f;
     public float apRatio = 0f;
@@ -152,40 +137,22 @@ public class DashParams : ISkillParam, IHasCooldown, IFollowUpProvider, ITargeti
 
     [Header("I-Frame/Status")]
     public bool grantIFrame = true;
-    public float iFrameDuration = 0.18f;     // 보통 duration과 동일
+    public float iFrameDuration = 0.18f;
 
     [Header("Timing")]
     public float cooldown = 0.35f;
     public float Cooldown => cooldown;
 
     [Header("FollowUps")]
-    public List<MechanicRef> onExpire = new(); // 대시 종료 후 후속(예: 원형 베기)
-	public IEnumerable<(CastOrder, float, bool)> BuildFollowUps(AbilityHook hook, Transform prevTarget)
-	{
-		if (hook != AbilityHook.OnCastEnd || onExpire == null) yield break;
-		foreach (var m in onExpire)
-		{
-			Debug.Log(m);
-			if (m.TryBuildOrder(null, out var order))
-			{
-				Debug.Log($"Callback {order.Mech}!");
-				yield return (order, m.delay, m.respectBusyCooldown);
-			}
-			else
-			{
-				Debug.Log("No callback...");
-				yield break;
-			}
-		}
-	}
-	/*public IEnumerable<(CastOrder, float, bool)> BuildFollowUps(AbilityHook hook, Transform prevTarget)
-    {
-        if (hook != AbilityHook.OnExpire || onExpire == null) yield break;
-        foreach (var m in onExpire)
-            if (m.TryBuildOrder(null, out var order))
-                yield return (order, m.delay, m.respectBusyCooldown);
-    }*/
+    public List<MechanicRef> onExpire = new();
 
+    public IEnumerable<(CastOrder, float, bool)> BuildFollowUps(AbilityHook hook, Transform prevTarget)
+    {
+        if (hook != AbilityHook.OnCastEnd || onExpire == null) yield break;
+        foreach (var mref in onExpire)
+            if (mref.TryBuildOrder(prevTarget, out var order))
+                yield return (order, mref.delay, mref.respectBusyCooldown);
+    }
 }
 
 [System.Serializable]
@@ -195,13 +162,13 @@ public class SwitchControllerParams : ISkillParam, ISwitchPolicy
     public List<MechanicRef> steps = new();
 
     [Min(0)] public int startIndex = 0;
-    public bool advanceOnCast = true; // false면 OnHit 등에서 수동 전진
+    public bool advanceOnCast = true;
 
-    // 런타임 커서(캐릭터별로 SerializeReference Param이 보관하므로 인스펙터 전역 영향 없음)
     [System.NonSerialized] int _idx = -1;
 
-    public bool TrySelect(Transform owner, Camera cam, out CastOrder order)
+    public bool TrySelect(Transform owner, Camera cam, out MechanicRef reference, out CastOrder order)
     {
+        reference = default;
         order = default;
         if (steps == null || steps.Count == 0) return false;
 
@@ -209,11 +176,10 @@ public class SwitchControllerParams : ISkillParam, ISwitchPolicy
         int cur = _idx;
         if (advanceOnCast) _idx = (_idx + 1) % steps.Count;
 
-        var mref = steps[cur];
-        return mref.TryBuildOrder(prevTarget: null, out order);
+        reference = steps[cur];
+        return reference.TryBuildOrder(prevTarget: null, out order);
     }
 
-    // 필요하면 OnHit에서 수동 전진할 수 있도록 헬퍼 제공
     public void AdvanceExplicit()
     {
         if (steps == null || steps.Count == 0) return;

--- a/Assets/Scripts/BasicMoves/ProjectileMechanics.cs
+++ b/Assets/Scripts/BasicMoves/ProjectileMechanics.cs
@@ -5,29 +5,34 @@ using System.Collections;
 [CreateAssetMenu(menuName = "Mechanics/Projectile (Homing, Targeted)")]
 public class ProjectileMechanics : SkillMechanismBase<MissileParams>, ITargetedMechanic
 {
-    // Å¸±êÇü ÁøÀÔÁ¡
-    public IEnumerator Cast(Transform owner, Camera cam, ISkillParam p, Transform target)
+    protected override IEnumerator Execute(MechanismContext ctx, MissileParams p)
     {
-        return Cast(owner, cam, (MissileParams)p, target);
-    }
+        var owner = ctx.Owner;
+        if (!owner)
+        {
+            Debug.LogWarning("[ProjectileMechanics] Owner transformê°€ ì¡´ì¬í•˜ì§€ ì•ŠìŠµë‹ˆë‹¤.");
+            yield break;
+        }
 
-    // ÀÏ¹İ ÁøÀÔÁ¡Àº »ç¿ë ¾È ÇÔ(ÇÊ¿äÇÏ¸é Ä¿¼­ ¹æÇâ ±âº» ¹ß»ç·Î ´ëÃ¼ °¡´É)
-    public override IEnumerator Cast(Transform owner, Camera cam, MissileParams p)
-    {
-        Debug.Log("Homing Missile Casted Without any target"); //»ç½Ç»ó ÀÌ log´Â ¾È ³ª¿Í¾ß ÇÔ. ÀÌ°Ô ³ª¿À¸é SkillRunner°¡ ÀÌ»óÇÏ´Ù´Â Áõ°Å
-        yield break; 
-    }
-
-    // ½ÇÁ¦ ·ÎÁ÷
-    IEnumerator Cast(Transform owner, Camera cam, MissileParams p, Transform target) //Camera camÀº ¾îµğ¿¡ ¾²´Â °Í? Ä«¸Ş¶ó ¿öÅ©¿¡ ÇÊ¿ä?
-    {
-        Debug.Log($"Homing Missile Casted with target {target.name}");
-        if (target == null) yield break;
+        if (!ctx.HasTarget)
+        {
+            Debug.LogWarning("[ProjectileMechanics] Targetì´ ì—†ì–´ ê¸°ë³¸ ë°œì‚¬ë¥¼ ìˆ˜í–‰í•˜ì§€ ì•ŠìŠµë‹ˆë‹¤.");
+            yield break;
+        }
 
         var go = new GameObject("HomingProjectile");
         go.transform.position = owner.position;
         var mover = go.AddComponent<ProjectileMovement>();
-        mover.Init(p, owner, target);
+        mover.Init(p, ctx);
+
+        // 1í”„ë ˆì„ ë™ì•ˆ ìƒì„±ëœ íˆ¬ì‚¬ì²´ì˜ ì´ˆê¸°í™”ê°€ ì™„ë£Œë˜ë„ë¡ ëŒ€ê¸°í•©ë‹ˆë‹¤.
         yield return null;
+    }
+
+    public IEnumerator Cast(MechanismContext ctx, ISkillParam param, Transform target)
+    {
+        if (param is not MissileParams missile)
+            throw new System.InvalidOperationException($"Param type mismatch. Need {nameof(MissileParams)}");
+        return Execute(ctx.WithTarget(target), missile);
     }
 }

--- a/Assets/Scripts/BasicMoves/ProjectileMovement.cs
+++ b/Assets/Scripts/BasicMoves/ProjectileMovement.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using SkillInterfaces;
 using ActInterfaces;
 using System;
 using System.Collections.Generic;
@@ -6,89 +7,87 @@ using System.Collections.Generic;
 public class ProjectileMovement : MonoBehaviour, IExpirable
 {
     MissileParams P;
+    MechanismContext ctx;
     Transform owner, target;
     Vector2 dir;
     float speed, traveled, life;
+    bool ended;
     public float Lifespan => life;
 
-    // ★ 이미 맞춘 콜라이더 재타격 방지
     readonly HashSet<int> _hitIds = new();
-    const float SKIN = 0.01f; // 충돌면을 살짝 넘어가도록
+    const float SKIN = 0.01f;
 
-    public void Init(MissileParams p, Transform owner, Transform target)
+    public void Init(MissileParams p, MechanismContext context)
     {
-        P = p; this.owner = owner; this.target = target;
-        Vector2 start = owner.position;
+        P = p;
+        ctx = context;
+        owner = context.Owner;
+        target = context.Target;
+
+        Vector2 start = owner ? (Vector2)owner.position : Vector2.zero;
         Vector2 tgt = target ? (Vector2)target.position : start + Vector2.right;
-        dir = (tgt - start).normalized;
+        dir = (tgt - start).sqrMagnitude > 1e-6f ? (tgt - start).normalized : Vector2.right;
         speed = P.speed;
 
         var sr = gameObject.AddComponent<SpriteRenderer>();
         sr.sprite = GenerateDotSprite();
         sr.sortingOrder = 1000;
         transform.localScale = Vector3.one * (P.radius * 2f);
-		//Debug.Log($"target {this.target.name}");
     }
 
     void Update()
     {
         float dt = Time.deltaTime;
-        life += dt; if (life > P.maxLife) { Expire(); }
+        life += dt;
+        if (life > P.maxLife)
+        {
+            Expire();
+            return;
+        }
 
-        // 가속
         speed = Mathf.Max(0f, speed + P.acceleration * dt);
 
-        // 타깃 유효성 확인 + 재타깃팅
         if (target == null && P.retargetOnLost)
             TryRetarget();
 
         Vector2 pos = transform.position;
+        Vector2 desired = target ? (Vector2)target.position - pos : dir;
+        float maxTurnRad = P.maxTurnDegPerSec * Mathf.Deg2Rad * dt;
+        dir = Vector3.RotateTowards(dir, desired.normalized, maxTurnRad, 0f).normalized;
 
-		// 원하는 방향(유도)
-		//Vector2 desired = target ? ((Vector2)target.position - pos).normalized : dir;
-		Vector2 desired = target?.name == "Anchor" ? dir : ((Vector2)target.position - pos).normalized;
-		float maxTurnRad = P.maxTurnDegPerSec * Mathf.Deg2Rad * dt;
-        dir = Vector3.RotateTowards(dir, desired, maxTurnRad, 0f).normalized;
-
-        // === 이동/충돌(여러 번) 처리 ===
         float remaining = speed * dt;
 
         while (remaining > 0f)
         {
             pos = transform.position;
 
-            // 1) 벽 체크
             var wallHit = Physics2D.CircleCast(pos, P.radius, dir, remaining, P.blockerMask);
             if (wallHit.collider)
             {
-                // 벽까지 이동 후 소멸
                 Move(wallHit.distance);
                 Expire();
                 return;
             }
 
-            // 2) 적 체크
             var enemyHit = Physics2D.CircleCast(pos, P.radius, dir, remaining, P.enemyMask);
             if (enemyHit.collider)
             {
                 var c = enemyHit.collider;
-
-                // 같은 콜라이더 중복 타격 방지
                 int id = c.GetInstanceID();
                 if (!_hitIds.Contains(id))
                 {
-                    // 충돌점까지 이동
                     Move(enemyHit.distance);
 
-                    // 피해/넉백 적용
                     if (c.TryGetComponent(out IVulnerable v))
+                    {
                         v.TakeDamage(P.damage, P.apRatio);
+                        ctx.EmitHook(AbilityHook.OnHit, c.transform, enemyHit.point, nameof(ProjectileMovement));
+                    }
                     if (c.attachedRigidbody)
                         c.attachedRigidbody.AddForce(dir * P.knockback, ForceMode2D.Impulse);
 
-                    _hitIds.Add(id); // 기록
+                    _hitIds.Add(id);
 
-                    // 관통 불가이거나(=명중 즉시 소멸) / 타깃 그 자체면 소멸
                     if (!P.CanPenetrate || (target != null && c.transform == target))
                     {
                         Expire();
@@ -97,25 +96,20 @@ public class ProjectileMovement : MonoBehaviour, IExpirable
                 }
                 else
                 {
-                    // 이미 맞춘 대상이면 충돌점까지는 굳이 안 멈추고 통과 처리
                     Move(enemyHit.distance);
                 }
 
-                // 충돌면을 살짝 넘어가 다음 캐스트에서 같은 면에 걸리지 않게
                 Move(SKIN);
-
-                // 잔여 거리 갱신
                 remaining -= enemyHit.distance + SKIN;
-                continue; // 다음 충돌/이동 처리
+                continue;
             }
 
-            // 3) 충돌 없으면 남은 거리만큼 이동하고 종료
             Move(remaining);
             remaining = 0f;
         }
 
-        // 사거리 체크
-        if (traveled >= P.maxRange) Expire();
+        if (traveled >= P.maxRange)
+            Expire();
     }
 
     void Move(float d)
@@ -127,26 +121,36 @@ public class ProjectileMovement : MonoBehaviour, IExpirable
     void TryRetarget()
     {
         var hits = Physics2D.OverlapCircleAll(transform.position, P.retargetRadius, P.enemyMask);
-        float best = float.PositiveInfinity; Transform bestT = null;
+        float best = float.PositiveInfinity;
+        Transform bestT = null;
         foreach (var h in hits)
         {
-            float d = Vector2.SqrMagnitude((Vector2)h.bounds.center - (Vector2)transform.position);
-            if (d < best) { best = d; bestT = h.transform; }
+            float dist = Vector2.SqrMagnitude((Vector2)h.bounds.center - (Vector2)transform.position);
+            if (dist < best)
+            {
+                best = dist;
+                bestT = h.transform;
+            }
         }
         if (bestT) target = bestT;
     }
 
     Sprite GenerateDotSprite()
     {
-        int s = 8; var tex = new Texture2D(s, s, TextureFormat.RGBA32, false);
-        var col = new Color32[s * s]; for (int i = 0; i < col.Length; i++) col[i] = new Color32(255, 255, 255, 255);
-        tex.SetPixels32(col); tex.Apply();
+        int s = 8;
+        var tex = new Texture2D(s, s, TextureFormat.RGBA32, false);
+        var col = new Color32[s * s];
+        for (int i = 0; i < col.Length; i++) col[i] = new Color32(255, 255, 255, 255);
+        tex.SetPixels32(col);
+        tex.Apply();
         return Sprite.Create(tex, new Rect(0, 0, s, s), new Vector2(0.5f, 0.5f), s);
     }
 
     public void Expire()
     {
-		//제거될 때 뭔가 해야 한다?
+        if (ended) return;
+        ended = true;
+        ctx.EmitHook(AbilityHook.OnCastEnd, target, transform.position, nameof(ProjectileMovement));
         Destroy(gameObject);
     }
 }

--- a/Assets/Scripts/BasicMoves/SwitchSkillMechanic.cs
+++ b/Assets/Scripts/BasicMoves/SwitchSkillMechanic.cs
@@ -5,10 +5,20 @@ using SkillInterfaces;
 [CreateAssetMenu(menuName = "Mechanics/Switch Controller")]
 public class SwitchSkillMechanic : SkillMechanismBase<SwitchControllerParams>
 {
-    // º»¹®Àº ¾Æ¹« °Íµµ ÇÏÁö ¾Ê½À´Ï´Ù.
-    // ½ÇÇà/¼±ÅÃÀº Runner°¡ Param(ISwitchPolicy)¿¡°Ô À§ÀÓÇÏ¿© ¼öÇàÇÕ´Ï´Ù.
-    public override IEnumerator Cast(Transform owner, Camera cam, SwitchControllerParams p)
+    protected override IEnumerator Execute(MechanismContext ctx, SwitchControllerParams p)
     {
+        var owner = ctx.Owner;
+        if (p.TrySelect(owner, ctx.Camera, out var reference, out var order))
+        {
+            ctx.ScheduleFollowUp(order, reference.delay, reference.respectBusyCooldown, AbilityHook.OnCastEnd, nameof(SwitchSkillMechanic));
+        }
+        else
+        {
+            Debug.LogWarning("[SwitchSkillMechanic] ì„ íƒ ê°€ëŠ¥í•œ ì£¼ë¬¸ì´ ì—†ìŠµë‹ˆë‹¤.");
+        }
+
+        Vector2? hookPoint = owner ? (Vector2)owner.position : (Vector2?)null;
+        ctx.EmitHook(AbilityHook.OnCastEnd, ctx.Target, hookPoint, nameof(SwitchSkillMechanic));
         yield break;
     }
 }

--- a/Assets/Scripts/Generals/Caster.cs
+++ b/Assets/Scripts/Generals/Caster.cs
@@ -26,7 +26,7 @@ public interface IFollowUpProvider
 /// Switch 정책(오직 Param만 구현) — 실행 직전에 선택할 주문 1개
 public interface ISwitchPolicy
 {
-    bool TrySelect(Transform owner, Camera cam, out CastOrder order);
+    bool TrySelect(Transform owner, Camera cam, out MechanicRef reference, out CastOrder order);
 }
 
 /// Param이 참조하는 “다음 기술”

--- a/Assets/Scripts/Generals/IntentOrchestrator.cs
+++ b/Assets/Scripts/Generals/IntentOrchestrator.cs
@@ -1,0 +1,47 @@
+using SkillInterfaces;
+using UnityEngine;
+
+/// <summary>
+/// IntentOrchestrator는 메커니즘 실행 중 발생하는 의도(Intent)를 중앙에서 중재합니다.
+/// - 현재는 FollowUp 스케줄링과 훅(AbilityHook) 브로드캐스트를 SkillRunner에게 위임합니다.
+/// - 차후 VFX/사운드/카메라 셰이크 등 부가 연출을 연결하려면 이 클래스를 확장하십시오.
+/// </summary>
+public sealed class IntentOrchestrator : MonoBehaviour
+{
+    [SerializeField, Tooltip("동일 게임오브젝트 혹은 부모에서 탐색되는 SkillRunner 참조")]
+    SkillRunner runner;
+
+    SkillRunner Runner
+    {
+        get
+        {
+            if (!runner)
+                runner = GetComponent<SkillRunner>() ?? GetComponentInParent<SkillRunner>();
+            return runner;
+        }
+    }
+
+    /// <summary>
+    /// AbilityHook을 SkillRunner에게 위임하여 FollowUp을 처리합니다.
+    /// worldPoint는 선택 사항이며 추후 VFX/카메라 연동 시 활용 가능합니다.
+    /// </summary>
+    public void EmitHook(AbilityHook hook, ISkillParam sourceParam, Transform prevTarget, Vector2? worldPoint, string debugTag)
+    {
+        if (sourceParam == null) return;
+        Runner?.EmitHook(hook, prevTarget, sourceParam, worldPoint, debugTag ?? name);
+    }
+
+    /// <summary>
+    /// 메커니즘이 명시적으로 FollowUp 주문을 예약하고자 할 때 사용합니다.
+    /// reason은 디버깅 로그를 위한 Hook 분류 값입니다.
+    /// </summary>
+    public void ScheduleFollowUp(CastOrder order, float delay, bool respectBusyCooldown, AbilityHook reason, string debugTag)
+    {
+        Runner?.ScheduleFollowUp(order, delay, respectBusyCooldown, reason, debugTag ?? name);
+    }
+
+    /**
+     * TODO: Intent 단계에서 별도의 버프/디버프, 상태이상, VFX, SFX 등을 일괄 처리하려면
+     *       ExecuteEffect, PlayVfx, PlaySfx 등의 API를 여기에 추가하십시오.
+     */
+}

--- a/Assets/Scripts/Generals/Interfaces.cs
+++ b/Assets/Scripts/Generals/Interfaces.cs
@@ -218,11 +218,11 @@ namespace SkillInterfaces
     public interface ISkillMechanic
     {
         System.Type ParamType { get; }
-        IEnumerator Cast(Transform owner, Camera cam, ISkillParam param);
+        IEnumerator Cast(MechanismContext context, ISkillParam param);
     }
     public interface ITargetedMechanic : ISkillMechanic
     {
-        IEnumerator Cast(Transform owner, Camera cam, ISkillParam param, Transform target);
+        IEnumerator Cast(MechanismContext context, ISkillParam param, Transform target);
     }
 
     // 제네릭 베이스: 타입 가드 + 제네릭 오버로드
@@ -232,15 +232,15 @@ namespace SkillInterfaces
     {
         public System.Type ParamType => typeof(TParam);
 
-        public IEnumerator Cast(Transform owner, Camera cam, ISkillParam param)
+        public IEnumerator Cast(MechanismContext context, ISkillParam param)
         {
             if (param is not TParam p)
                 throw new System.InvalidOperationException(
                     $"Param type mismatch. Need {typeof(TParam).Name}, got {param?.GetType().Name ?? "null"}");
-            return Cast(owner, cam, p);
+            return Execute(context, p);
         }
-        
-        public abstract IEnumerator Cast(Transform owner, Camera cam, TParam param);
+
+        protected abstract IEnumerator Execute(MechanismContext context, TParam param);
     }
     public enum TargetMode { TowardsEnemy, TowardsCursor, TowardsMovement, TowardsOffset }
     

--- a/Assets/Scripts/Generals/MechanismContext.cs
+++ b/Assets/Scripts/Generals/MechanismContext.cs
@@ -1,0 +1,78 @@
+using UnityEngine;
+using SkillInterfaces;
+
+/// <summary>
+/// SkillRunner가 메커니즘 실행 시 제공하는 컨텍스트입니다.
+/// - FollowUp 실행, 훅 브로드캐스트, 대상/주문 정보 등을 한 곳에서 참조합니다.
+/// - 구조체이지만 참조 필드를 보유하므로 값 복사에 유의하십시오.
+/// </summary>
+public readonly struct MechanismContext
+{
+    public Transform Owner { get; }
+    public Camera Camera { get; }
+    public Transform Target { get; }
+    public SkillRunner Runner { get; }
+    public IntentOrchestrator Orchestrator { get; }
+    public CastOrder Order { get; }
+    public GameEventMeta Meta { get; }
+    public SkillRef SkillRef { get; }
+
+    public bool HasTarget => Target != null;
+    public string MechanismName => Order.Mech?.GetType().Name ?? "<Mechanism>";
+
+    public MechanismContext(Transform owner, Camera camera, Transform target,
+        SkillRunner runner, IntentOrchestrator orchestrator,
+        CastOrder order, GameEventMeta meta, SkillRef skillRef)
+    {
+        Owner = owner;
+        Camera = camera;
+        Target = target;
+        Runner = runner;
+        Orchestrator = orchestrator;
+        Order = order;
+        Meta = meta;
+        SkillRef = skillRef;
+    }
+
+    public MechanismContext WithTarget(Transform target)
+        => new MechanismContext(Owner, Camera, target, Runner, Orchestrator, Order, Meta, SkillRef);
+
+    /// <summary>
+    /// AbilityHook을 전파합니다. FollowUpProvider가 설정되어 있다면 자동으로 후속 주문이 예약됩니다.
+    /// </summary>
+    public void EmitHook(AbilityHook hook, Transform prevTarget = null, Vector2? worldPoint = null, string debugTag = null)
+    {
+        var source = Order.Param;
+        if (source == null) return;
+
+        if (Orchestrator)
+        {
+            Orchestrator.EmitHook(hook, source, prevTarget ?? Target, worldPoint, debugTag ?? MechanismName);
+        }
+        else
+        {
+            Runner?.EmitHook(hook, prevTarget ?? Target, source, worldPoint, debugTag ?? MechanismName);
+        }
+    }
+
+    /// <summary>
+    /// FollowUp 주문을 직접 예약합니다. Hook 단계 외의 커스텀 로직에서 활용하십시오.
+    /// </summary>
+    public void ScheduleFollowUp(CastOrder order, float delay, bool respectBusyCooldown, AbilityHook reason, string debugTag = null)
+    {
+        if (order.Mech == null || order.Param == null) return;
+        if (Orchestrator)
+        {
+            Orchestrator.ScheduleFollowUp(order, delay, respectBusyCooldown, reason, debugTag ?? MechanismName);
+        }
+        else
+        {
+            Runner?.ScheduleFollowUp(order, delay, respectBusyCooldown, reason, debugTag ?? MechanismName);
+        }
+    }
+
+    /**
+     * TODO: Owner/Camera 외에도 CombatStatContext, AnimationController 등 확장 의존성이 필요하다면
+     *       해당 필드와 유틸리티 메서드를 추가하고 SkillRunner에서 값을 세팅하십시오.
+     */
+}


### PR DESCRIPTION
## Summary
- add a reusable `MechanismContext` plus `IntentOrchestrator` so mechanics can emit hooks and schedule follow-ups consistently
- update `SkillRunner`, `Caster`, and move parameter classes to expose the new context-based APIs and switch-selection metadata
- refactor melee, dash, projectile, and switch mechanics (and projectile movement) to operate through the shared context and report hooks

## Testing
- Not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68db8a9f8dbc832c88a13b8d140d5107