### PR TITLE
Implement flexible targeting options

### DIFF
--- a/Assets/Scripts/BasicMoves/DashMechanism.cs
+++ b/Assets/Scripts/BasicMoves/DashMechanism.cs
@@ -30,111 +30,118 @@ public class DashMechanism : SkillMechanismBase<DashParams>, ITargetedMechanic
 			yield break;
 		}
 
-		var solution = TargetingRuntimeUtil.Resolve(owner, cam, p, explicitTarget, createAnchor: false);
-		Transform dashTarget = solution.IsSyntheticTarget ? null : solution.Target;
-		Vector2 fallbackDir = solution.Direction.sqrMagnitude > 0f ? solution.Direction.normalized : (Vector2)owner.right;
-		float desiredDist = dashTarget ? Vector2.Distance(owner.position, dashTarget.position) : solution.Distance;
-		Debug.Log($"DashMechanism: 대시 대상 {dashTarget?.name ?? "null"}, fallbackDir {fallbackDir}, desiredDist {desiredDist}");
-		if (dashTarget && p.FallbackRange > 0f)
-		{
-			desiredDist = Mathf.Min(desiredDist, p.FallbackRange);
-		}
-		else if (!dashTarget && p.FallbackRange > 0f)
-		{
-			desiredDist = Mathf.Max(p.FallbackRange, desiredDist);
-		}
-		desiredDist = Mathf.Max(0f, desiredDist);
-		if (desiredDist <= 0f)
-		{
-			Debug.LogWarning("DashMechanism: 이동 거리가 0이라 대시를 생략합니다.");
-			yield break;
-		}
+                var solution = TargetingRuntimeUtil.Resolve(owner, cam, p, explicitTarget, createAnchor: false, targetSelf: p.TargetSelf);
+                try
+                {
+                        Transform dashTarget = solution.IsSyntheticTarget ? null : solution.Target;
+                        Vector2 fallbackDir = solution.Direction.sqrMagnitude > 0f ? solution.Direction.normalized : (Vector2)owner.right;
+                        float desiredDist = dashTarget ? Vector2.Distance(owner.position, dashTarget.position) : solution.Distance;
+                        Debug.Log($"DashMechanism: 대시 대상 {dashTarget?.name ?? "null"}, fallbackDir {fallbackDir}, desiredDist {desiredDist}");
+                        if (dashTarget && p.FallbackRange > 0f)
+                        {
+                                desiredDist = Mathf.Min(desiredDist, p.FallbackRange);
+                        }
+                        else if (!dashTarget && p.FallbackRange > 0f)
+                        {
+                                desiredDist = Mathf.Max(p.FallbackRange, desiredDist);
+                        }
+                        desiredDist = Mathf.Max(0f, desiredDist);
+                        if (desiredDist <= 0f)
+                        {
+                                Debug.LogWarning("DashMechanism: 이동 거리가 0이라 대시를 생략합니다.");
+                                yield break;
+                        }
 
-		MechanismRuntimeUtil.QueueFollowUps(p, AbilityHook.OnCastStart, dashTarget, "Dash");
+                        MechanismRuntimeUtil.QueueFollowUps(p, AbilityHook.OnCastStart, dashTarget, "Dash");
 
-		if (p.grantIFrame && p.iFrameDuration > 0f)
-		{
-			// Publish(new EffectApplyReq(Create(owner,"combat"), owner, new IFrameEffect(), p.iFrameDuration));
-		}
+                        if (p.grantIFrame && p.iFrameDuration > 0f)
+                        {
+                                // Publish(new EffectApplyReq(Create(owner,"combat"), owner, new IFrameEffect(), p.iFrameDuration));
+                        }
 
-		Vector2 dir0 = fallbackDir.sqrMagnitude > 1e-4f ? fallbackDir : (Vector2)owner.right;
-		float remaining = desiredDist;
+                        Vector2 dir0 = fallbackDir.sqrMagnitude > 1e-4f ? fallbackDir : (Vector2)owner.right;
+                        float remaining = desiredDist;
 
-		var basePolicy = motor.CurrentPolicy;
-		var dashPolicy = basePolicy;
-		dashPolicy.wallsMask = p.WallsMask;
-		dashPolicy.enemyMask = p.enemyMask;
-		dashPolicy.enemyAsBlocker = !p.CanPenetrate;
-		dashPolicy.radius = p.radius;
-		dashPolicy.skin = Mathf.Max(0.01f, p.skin);
-		dashPolicy.allowWallSlide = true;
+                        var basePolicy = motor.CurrentPolicy;
+                        var dashPolicy = basePolicy;
+                        dashPolicy.wallsMask = p.WallsMask;
+                        dashPolicy.enemyMask = p.enemyMask;
+                        dashPolicy.enemyAsBlocker = !p.CanPenetrate;
+                        dashPolicy.radius = p.radius;
+                        dashPolicy.skin = Mathf.Max(0.01f, p.skin);
+                        dashPolicy.allowWallSlide = true;
 
-		using (motor.With(dashPolicy))
-		{
-			var hitIds = new HashSet<int>();
-			float elapsed = 0f;
-			float total = Mathf.Max(0.01f, p.duration);
+                        using (motor.With(dashPolicy))
+                        {
+                                var hitIds = new HashSet<int>();
+                                float elapsed = 0f;
+                                float total = Mathf.Max(0.01f, p.duration);
 
-			while (remaining > 0f)
-			{
-				using (motor.With(dashPolicy))
-				{
-					// 센서 기반 확장을 위한 placeholder입니다.
-				}
+                                while (remaining > 0f)
+                                {
+                                        using (motor.With(dashPolicy))
+                                        {
+                                                // 센서 기반 확장을 위한 placeholder입니다.
+                                        }
 
-				float tNorm = Mathf.Clamp01(elapsed / total);
-				float nominalSpeed = (desiredDist / total) * p.speedCurve.Evaluate(tNorm);
-				float stepDist = Mathf.Min(remaining, nominalSpeed * Time.deltaTime);
+                                        float tNorm = Mathf.Clamp01(elapsed / total);
+                                        float nominalSpeed = (desiredDist / total) * p.speedCurve.Evaluate(tNorm);
+                                        float stepDist = Mathf.Min(remaining, nominalSpeed * Time.deltaTime);
 
-				Vector2 pos = owner.position;
-				Vector2 aim = dashTarget ? (Vector2)dashTarget.position - pos : fallbackDir;
-				Vector2 dir = aim.sqrMagnitude > 1e-4f ? aim.normalized : dir0;
+                                        Vector2 pos = owner.position;
+                                        Vector2 aim = dashTarget ? (Vector2)dashTarget.position - pos : fallbackDir;
+                                        Vector2 dir = aim.sqrMagnitude > 1e-4f ? aim.normalized : dir0;
 
-				motor.Depenetration();
-				var res = motor.SweepMove(dir * stepDist);
-				motor.Depenetration();
-				remaining -= res.actualDelta.magnitude;
+                                        motor.Depenetration();
+                                        var res = motor.SweepMove(dir * stepDist);
+                                        motor.Depenetration();
+                                        remaining -= res.actualDelta.magnitude;
 
-				if (p.dealDamage && p.enemyMask.value != 0)
-				{
-					var hits = Physics2D.OverlapCircleAll(owner.position, p.radius, p.enemyMask);
-					foreach (var c in hits)
-					{
-						int id = c.GetInstanceID();
-						if (hitIds.Contains(id)) continue;
-						if (c.TryGetComponent(out ActInterfaces.IVulnerable v))
-						{
-							v.TakeDamage(p.damage, p.apRatio);
-							if (c.attachedRigidbody && p.knockback != 0f)
-							{
-								var kdir = ((Vector2)c.transform.position - (Vector2)owner.position).normalized;
-								c.attachedRigidbody.AddForce(kdir * p.knockback, ForceMode2D.Impulse);
-							}
-							hitIds.Add(id);
-							Publish(new DamageDealt(Create(owner, "combat"), owner, c.transform,
-									p.damage, p.damage, 0f, EDamageType.Normal, owner.position, dir));
-						}
-					}
-				}
+                                        if (p.dealDamage && p.enemyMask.value != 0)
+                                        {
+                                                var hits = Physics2D.OverlapCircleAll(owner.position, p.radius, p.enemyMask);
+                                                foreach (var c in hits)
+                                                {
+                                                        int id = c.GetInstanceID();
+                                                        if (hitIds.Contains(id)) continue;
+                                                        if (c.TryGetComponent(out ActInterfaces.IVulnerable v))
+                                                        {
+                                                                v.TakeDamage(p.damage, p.apRatio);
+                                                                if (c.attachedRigidbody && p.knockback != 0f)
+                                                                {
+                                                                        var kdir = ((Vector2)c.transform.position - (Vector2)owner.position).normalized;
+                                                                        c.attachedRigidbody.AddForce(kdir * p.knockback, ForceMode2D.Impulse);
+                                                                }
+                                                                hitIds.Add(id);
+                                                                Publish(new DamageDealt(Create(owner, "combat"), owner, c.transform,
+                                                                                p.damage, p.damage, 0f, EDamageType.Normal, owner.position, dir));
+                                                        }
+                                                }
+                                        }
 
-				if (res.hitWall) break;
+                                        if (res.hitWall) break;
 
-				if (dashTarget && dashTarget.TryGetComponent<Collider2D>(out _))
-				{
-					float arrive = p.radius + p.skin;
-					if (((Vector2)dashTarget.position - (Vector2)owner.position).sqrMagnitude <= arrive * arrive)
-						break;
-				}
+                                        if (dashTarget && dashTarget.TryGetComponent<Collider2D>(out _))
+                                        {
+                                                float arrive = p.radius + p.skin;
+                                                if (((Vector2)dashTarget.position - (Vector2)owner.position).sqrMagnitude <= arrive * arrive)
+                                                        break;
+                                        }
 
-				elapsed += Time.deltaTime;
-				if (elapsed >= total) break;
+                                        elapsed += Time.deltaTime;
+                                        if (elapsed >= total) break;
 
-				yield return null;
-			}
+                                        yield return null;
+                                }
 
-			motor.Depenetration();
-		}
+                                motor.Depenetration();
+                        }
 
-		MechanismRuntimeUtil.QueueFollowUps(p, AbilityHook.OnCastEnd, dashTarget, "Dash");
+                        MechanismRuntimeUtil.QueueFollowUps(p, AbilityHook.OnCastEnd, dashTarget, "Dash");
+                }
+                finally
+                {
+                        solution.DisposeAnchor();
+                }
 	}
 }

--- a/Assets/Scripts/BasicMoves/MoveParams.cs
+++ b/Assets/Scripts/BasicMoves/MoveParams.cs
@@ -77,13 +77,29 @@ public class MissileParams : ISkillParam, IHasCooldown, IFollowUpProvider, ITarg
 	public float endDelay = 0.05f;
 	public float Cooldown => cooldown;
 
-	[Header("Behavior")]
-	public bool retargetOnLost = true;
-	public float retargetRadius = 3f;
-	[Header("Targeter")]
-	public TargetMode mode; public float fallback = 10f; public Vector2 local; public float col; public float skin; public bool canpen;
-	public TargetMode Mode => mode; public float FallbackRange => fallback; public Vector2 LocalOffset => local; public LayerMask WallsMask => blockerMask;
-	public float CollisionRadius => col; public float AnchorSkin => skin; public bool CanPenetrate => canpen;
+        [Header("Behavior")]
+        public bool retargetOnLost = true;
+        public float retargetRadius = 3f;
+
+        [Header("Targeting")]
+        [Tooltip("Toggle to deliberately target the caster instead of searching for another entity.")]
+        public bool targetSelf = false;
+        public TargetMode mode;
+        public float fallback = 10f;
+        public Vector2 local;
+        public float col;
+        public float skin;
+        public bool canpen;
+
+        public TargetMode Mode => mode;
+        public float FallbackRange => fallback;
+        public Vector2 LocalOffset => local;
+        public LayerMask WallsMask => blockerMask;
+        public LayerMask TargetMask => enemyMask;
+        public bool TargetSelf => targetSelf;
+        public float CollisionRadius => col;
+        public float AnchorSkin => skin;
+        public bool CanPenetrate => canpen;
 
 
 	// ★ FollowUp 예: 맞으면 폭발, 소멸하면 잔류 디버프…
@@ -123,17 +139,20 @@ public class MissileParams : ISkillParam, IHasCooldown, IFollowUpProvider, ITarg
 public class DashParams : ISkillParam, IHasCooldown, IFollowUpProvider, ITargetingData, IAnchorClearance
 {
 	[Header("Targeting (Runner가 해석)")]
-	[SerializeField] TargetMode _mode = TargetMode.TowardsMovement;
-	[SerializeField] float _fallbackRange = 4f;
-	[SerializeField] Vector2 _localOffset = Vector2.zero;
-	[SerializeField] LayerMask _wallsMask;
-	[SerializeField] bool _canpen;
+        [SerializeField] TargetMode _mode = TargetMode.TowardsMovement;
+        [SerializeField] float _fallbackRange = 4f;
+        [SerializeField] Vector2 _localOffset = Vector2.zero;
+        [SerializeField] LayerMask _wallsMask;
+        [SerializeField] bool _canpen;
+        [SerializeField] bool _targetSelf;
 
-	public TargetMode Mode => _mode;
-	public float FallbackRange => _fallbackRange;
-	public Vector2 LocalOffset => _localOffset;
-	public LayerMask WallsMask => _wallsMask;
-	public bool CanPenetrate => _canpen;
+        public TargetMode Mode => _mode;
+        public float FallbackRange => _fallbackRange;
+        public Vector2 LocalOffset => _localOffset;
+        public LayerMask WallsMask => _wallsMask;
+        public LayerMask TargetMask => enemyMask;
+        public bool TargetSelf => _targetSelf;
+        public bool CanPenetrate => _canpen;
 
 	[Header("Motion")]
 	public float duration = 0.18f;           // 총 대시 시간

--- a/Assets/Scripts/BasicMoves/ProjectileMechanism.cs
+++ b/Assets/Scripts/BasicMoves/ProjectileMechanism.cs
@@ -37,7 +37,7 @@ public class ProjectileMechanism : SkillMechanismBase<MissileParams>, ITargetedM
 			if (!owner) yield break;
 		}
 
-		var solution = TargetingRuntimeUtil.Resolve(owner, cam, p, explicitTarget, createAnchor: true);
+                var solution = TargetingRuntimeUtil.Resolve(owner, cam, p, explicitTarget, createAnchor: true, targetSelf: p.TargetSelf);
 		Transform resolvedTarget = solution.Target;
 		Debug.Log($"ProjectileMechanism: 발사 대상 {resolvedTarget?.name ?? "null"}, 방향 {solution.Direction}, 거리 {solution.Distance}");
 		if (resolvedTarget == null)

--- a/Assets/Scripts/Generals/Interfaces.cs
+++ b/Assets/Scripts/Generals/Interfaces.cs
@@ -247,7 +247,7 @@ namespace SkillInterfaces
 		
 		public abstract IEnumerator Cast(Transform owner, Camera cam, TParam param);
 	}
-	public enum TargetMode { TowardsEnemy, TowardsCursor, TowardsMovement, TowardsOffset }
+        public enum TargetMode { TowardsEntity, TowardsCursor, TowardsMovement, TowardsCoordinate }
 	
 	public interface IAnchorClearance
 	{
@@ -255,12 +255,14 @@ namespace SkillInterfaces
 		float CollisionRadius { get; } // 스킬 충돌 반경(없으면 0)
 		float AnchorSkin { get; }     // 벽 앞 여유(0.03~0.08)
 	}
-	public interface ITargetingData : IAnchorClearance
-	{
-		TargetMode Mode { get; }
-		float FallbackRange { get; }  // FixedForward 거리
-		Vector2 LocalOffset { get; }  // FixedOffset
-		bool CanPenetrate { get; } // 논타깃: 적중 시에도 종료되지 않는가, 타깃: 대상에게 적중하기 전까지 종료되지 않는가
-	}
+        public interface ITargetingData : IAnchorClearance
+        {
+                TargetMode Mode { get; }
+                float FallbackRange { get; }  // FixedForward 거리
+                Vector2 LocalOffset { get; }  // FixedOffset (TowardsCoordinate 모드에서 사용)
+                LayerMask TargetMask { get; } // TowardsEntity 탐색 시 사용할 대상 마스크
+                bool TargetSelf { get; }      // true일 경우 명시적으로 자신을 대상으로 삼습니다.
+                bool CanPenetrate { get; } // 논타깃: 적중 시에도 종료되지 않는가, 타깃: 대상에게 적중하기 전까지 종료되지 않는가
+        }
 }
 #endregion

--- a/Assets/Scripts/Generals/TargetingRuntimeUtil.cs
+++ b/Assets/Scripts/Generals/TargetingRuntimeUtil.cs
@@ -44,25 +44,58 @@ public static class TargetingRuntimeUtil
             return new TargetingResult(explicitTarget, dir, distance, (Vector2)explicitTarget.position, null, false);
         }
 
+        if (targetSelf && owner != null)
+        {
+            var dirSelf = (Vector2)owner.right;
+            if (dirSelf.sqrMagnitude <= MinDirectionSqr)
+            {
+                dirSelf = Vector2.right;
+            }
+            return new TargetingResult(owner, dirSelf.normalized, 0f, owner.position, null, false);
+        }
+
         Vector2 desiredPoint = origin;
         Vector2 fallbackDir = owner.right;
         float fallbackDistance = data != null ? Mathf.Max(0f, data.FallbackRange) : 0f;
+        bool needsAnchor = createAnchor;
 
         if (data != null)
         {
             switch (data.Mode)
             {
+                case TargetMode.TowardsEntity:
+                    if (TryResolveEntityTarget(owner, cam, data, out var entityTarget))
+                    {
+                        var offset = (Vector2)entityTarget.position - origin;
+                        var ownerRight = (Vector2)owner.right;
+                        if (offset.sqrMagnitude <= MinDirectionSqr)
+                        {
+                            offset = ownerRight.sqrMagnitude > MinDirectionSqr ? ownerRight : Vector2.right;
+                        }
+                        float distance = offset.magnitude;
+                        var dir = offset.sqrMagnitude > MinDirectionSqr ? offset.normalized : ownerRight;
+                        if (dir.sqrMagnitude <= MinDirectionSqr)
+                        {
+                            dir = Vector2.right;
+                        }
+                        return new TargetingResult(entityTarget, dir.normalized, distance, (Vector2)entityTarget.position, null, false);
+                    }
+                    desiredPoint = origin + fallbackDir.normalized * Mathf.Max(data.FallbackRange, fallbackDistance);
+                    fallbackDistance = Mathf.Max(data.FallbackRange, fallbackDistance);
+                    break;
                 case TargetMode.TowardsCursor when cam != null:
                     var mouse = cam.ScreenToWorldPoint(Input.mousePosition);
                     mouse.z = owner.position.z;
                     desiredPoint = mouse;
                     fallbackDir = desiredPoint - origin;
                     fallbackDistance = fallbackDir.magnitude;
+                    needsAnchor = true;
                     break;
-                case TargetMode.TowardsOffset:
+                case TargetMode.TowardsCoordinate:
                     desiredPoint = owner.TransformPoint(data.LocalOffset);
                     fallbackDir = desiredPoint - origin;
                     fallbackDistance = fallbackDir.magnitude;
+                    needsAnchor = true;
                     break;
                 case TargetMode.TowardsMovement:
                     if (owner.TryGetComponent<IMovable>(out var mover) && mover.LastMoveDir.sqrMagnitude > MinDirectionSqr)
@@ -75,11 +108,7 @@ public static class TargetingRuntimeUtil
                     }
                     desiredPoint = origin + fallbackDir.normalized * Mathf.Max(data.FallbackRange, fallbackDistance);
                     fallbackDistance = data.FallbackRange;
-                    break;
-                case TargetMode.TowardsEnemy:
-                    /** 향후 Targeter 시스템과 연동하여 실제 적 탐색을 구현할 수 있도록 이 분기에서 Hook를 남겨둡니다. */
-                    desiredPoint = origin + fallbackDir.normalized * Mathf.Max(data.FallbackRange, fallbackDistance);
-                    fallbackDistance = Mathf.Max(data.FallbackRange, fallbackDistance);
+                    needsAnchor = true;
                     break;
                 default:
                     desiredPoint = origin + fallbackDir.normalized * Mathf.Max(data.FallbackRange, fallbackDistance);
@@ -113,7 +142,7 @@ public static class TargetingRuntimeUtil
 
         Transform anchor = null;
         bool synthetic = false;
-        if (createAnchor)
+        if (needsAnchor)
         {
             var anchorObj = new GameObject(AnchorName);
             anchorObj.transform.position = desiredPoint;
@@ -123,6 +152,93 @@ public static class TargetingRuntimeUtil
         }
 
         return new TargetingResult(anchor, fallbackDir, fallbackDistance, desiredPoint, anchor, synthetic);
+    }
+
+    static bool TryResolveEntityTarget(Transform owner, Camera cam, ITargetingData data, out Transform target)
+    {
+        target = null;
+        if (owner == null)
+        {
+            return false;
+        }
+
+        // 1) 우선 CursorHoverTargetProvider가 존재하면 그것을 그대로 사용합니다.
+        var provider = owner.GetComponentInChildren<CursorHoverTargetProvider>();
+        if (provider == null)
+        {
+            provider = Object.FindObjectOfType<CursorHoverTargetProvider>();
+        }
+        if (provider != null && provider.TryGetTarget(out var hovered))
+        {
+            target = hovered;
+            return target != null;
+        }
+
+        // 2) Provider가 없다면 CursorHoverTargeter의 로직을 인라인으로 재현합니다.
+        if (cam == null || data == null || data.TargetMask.value == 0)
+        {
+            return false;
+        }
+
+        var mouse = cam.ScreenToWorldPoint(Input.mousePosition);
+        if (owner != null)
+        {
+            mouse.z = owner.position.z;
+        }
+        Vector2 cursor = mouse;
+        Vector2 origin = owner ? (Vector2)owner.position : cursor;
+
+        var hits = Physics2D.OverlapPointAll(cursor, data.TargetMask);
+        if (hits.Length == 0)
+        {
+            hits = Physics2D.OverlapCircleAll(cursor, 0.0625f, data.TargetMask);
+        }
+        if (hits.Length == 0)
+        {
+            return false;
+        }
+
+        float maxRange = data.FallbackRange > 0f ? data.FallbackRange : float.PositiveInfinity;
+        Transform best = null;
+        float bestDist = float.PositiveInfinity;
+
+        foreach (var h in hits)
+        {
+            var collider = h;
+            var candidate = collider.transform;
+            var closest = collider.bounds.ClosestPoint(origin);
+            float distance = Vector2.Distance(origin, closest);
+            if (distance > maxRange)
+            {
+                continue;
+            }
+
+            bool blocked = false;
+            if (data.WallsMask.value != 0)
+            {
+                var hit = Physics2D.Linecast(origin, closest, data.WallsMask);
+                blocked = hit.collider != null && hit.collider.transform != candidate;
+            }
+
+            if (blocked)
+            {
+                continue;
+            }
+
+            if (distance < bestDist)
+            {
+                bestDist = distance;
+                best = candidate;
+            }
+        }
+
+        if (best == null)
+        {
+            return false;
+        }
+
+        target = best;
+        return true;
     }
 
     /// <summary>

--- a/Assets/Scripts/PlayerScripts/PlayerAttackController.cs
+++ b/Assets/Scripts/PlayerScripts/PlayerAttackController.cs
@@ -82,13 +82,19 @@ public class PlayerAttackController : MonoBehaviour
 		if (runner == null) return;
 		if (!slotBindings.TryGetValue(slot, out var binding)) return;
 
-		var request = new TargetRequest
-		{
-			Policy = TargetPolicy.SameAsCast,
-			ExplicitActor = transform,
-			Radius = 0f,
-			TeamMask = ~0,
-		};
+                Transform explicitActor = transform;
+                if (binding.param is ITargetingData targeting && !targeting.TargetSelf)
+                {
+                        explicitActor = null;
+                }
+
+                var request = new TargetRequest
+                {
+                        Policy = TargetPolicy.SameAsCast,
+                        ExplicitActor = explicitActor,
+                        Radius = 0f,
+                        TeamMask = ~0,
+                };
 
 		// 추후 목표 포인트(조준선/커서 등)를 반영할 경우 TargetRequest를 갱신해야 합니다.
 		runner.EnqueueRootIntent(binding.mech, binding.param, request, priorityLevel: 0);


### PR DESCRIPTION
## Summary
- add TowardsEntity/TowardsCursor/TowardsMovement/TowardsCoordinate modes and self-target toggle to targeting data
- update runtime targeting to search hovered entities, create anchors for positional targets, and dispose temporary anchors after dash
- ensure player casting only self-targets when requested and forward self-target option to dash/projectile skills

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68e854731e68832c9695c63306501519