### PR TITLE
Refactor KinematicMotor2D to core ticker

### DIFF
--- a/Assets/Scripts/BasicMoves/DashMechanism.cs
+++ b/Assets/Scripts/BasicMoves/DashMechanism.cs
@@ -77,28 +77,33 @@ public class DashMechanism : SkillMechanismBase<DashParams>, ITargetedMechanic
 								float elapsed = 0f;
 								float total = Mathf.Max(0.01f, p.duration);
 
-								while (remaining > 0f)
-								{
-										using (motor.With(dashPolicy))
-										{
-												// 센서 기반 확장을 위한 placeholder입니다.
-										}
+                                                                float tickDuration = 1f / Ticker.TicksPerSecond;
 
-										float tNorm = Mathf.Clamp01(elapsed / total);
-										float nominalSpeed = (desiredDist / total) * p.speedCurve.Evaluate(tNorm);
-										float stepDist = Mathf.Min(remaining, nominalSpeed * Time.deltaTime);
+                                                                while (remaining > 0f)
+                                                                {
+                                                                                using (motor.With(dashPolicy))
+                                                                                {
+                                                                                                // 센서 기반 확장을 위한 placeholder입니다.
+                                                                                }
 
-										Vector2 pos = owner.position;
-										Vector2 aim = dashTarget ? (Vector2)dashTarget.position - pos : fallbackDir;
-										Vector2 dir = aim.sqrMagnitude > 1e-4f ? aim.normalized : dir0;
+                                                                                float tNorm = Mathf.Clamp01(elapsed / total);
+                                                                                float nominalSpeed = (desiredDist / total) * p.speedCurve.Evaluate(tNorm);
+                                                                                float stepDist = Mathf.Min(remaining, nominalSpeed / Ticker.TicksPerSecond);
 
-										motor.Depenetration();
-										var res = motor.SweepMove(dir * stepDist);
-										motor.Depenetration();
-										remaining -= res.actualDelta.magnitude;
+                                                                                Vector2 pos = owner.position;
+                                                                                Vector2 aim = dashTarget ? (Vector2)dashTarget.position - pos : fallbackDir;
+                                                                                Vector2 dir = aim.sqrMagnitude > 1e-4f ? aim.normalized : dir0;
 
-										if (p.dealDamage && p.enemyMask.value != 0)
-										{
+                                                                                motor.Depenetration();
+                                                                                int awaitedTick = motor.LastProcessedTick;
+                                                                                motor.SweepMove(new FixedVector2(dir * stepDist));
+                                                                                yield return new WaitUntil(() => motor.LastProcessedTick > awaitedTick);
+                                                                                motor.Depenetration();
+                                                                                var res = motor.LastMoveResult;
+                                                                                remaining -= res.ActualDeltaVector.magnitude;
+
+                                                                                if (p.dealDamage && p.enemyMask.value != 0)
+                                                                                {
 												var hits = Physics2D.OverlapCircleAll(owner.position, p.radius, p.enemyMask);
 												foreach (var c in hits)
 												{
@@ -128,13 +133,12 @@ public class DashMechanism : SkillMechanismBase<DashParams>, ITargetedMechanic
 														break;
 										}
 
-										elapsed += Time.deltaTime;
-										if (elapsed >= total) break;
+                                                                                elapsed += tickDuration;
+                                                                                if (elapsed >= total) break;
 
-										yield return null;
-								}
+                                                                }
 
-								motor.Depenetration();
+                                                                motor.Depenetration();
 						}
 
 						MechanismRuntimeUtil.QueueFollowUps(p, AbilityHook.OnCastEnd, dashTarget, "Dash");

--- a/Assets/Scripts/Generals/BattleCore.cs
+++ b/Assets/Scripts/Generals/BattleCore.cs
@@ -1,0 +1,341 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// Provides the foundational global systems for the battle simulation layer.
+/// Ensure this class is touched before using other BattleCore utilities to
+/// guarantee that the internal runner MonoBehaviour exists.
+/// </summary>
+public static class BattleCore
+{
+    private static bool _initialized;
+    private static GameObject _runner;
+
+    static BattleCore()
+    {
+        Initialize();
+    }
+
+    /// <summary>
+    /// Global ticker operating with 60 ticks per real-time second.
+    /// </summary>
+    public static Ticker Ticker { get; } = new();
+
+    /// <summary>
+    /// Creates an invisible runner GameObject (if required) and keeps it alive across scenes.
+    /// </summary>
+    public static void Initialize()
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        _initialized = true;
+        _runner = new GameObject("[BattleCore]")
+        {
+            hideFlags = HideFlags.HideAndDontSave
+        };
+        UnityEngine.Object.DontDestroyOnLoad(_runner);
+
+        var runner = _runner.AddComponent<BattleCoreTickerRunner>();
+        runner.Initialize(Ticker);
+    }
+}
+
+/// <summary>
+/// Represents a deterministic 2D vector where 1.0f equals 1000 fixed units.
+/// </summary>
+[Serializable]
+public readonly struct FixedVector2
+{
+    public const int UnitsPerFloat = 1000;
+
+    [SerializeField] private readonly int _rawX;
+    [SerializeField] private readonly int _rawY;
+
+    /// <summary>
+    /// Raw X component (in fixed units).
+    /// </summary>
+    public int RawX => _rawX;
+
+    /// <summary>
+    /// Raw Y component (in fixed units).
+    /// </summary>
+    public int RawY => _rawY;
+
+    public FixedVector2(int rawX, int rawY)
+    {
+        _rawX = rawX;
+        _rawY = rawY;
+    }
+
+    public FixedVector2(float x, float y)
+    {
+        _rawX = Mathf.RoundToInt(x * UnitsPerFloat);
+        _rawY = Mathf.RoundToInt(y * UnitsPerFloat);
+    }
+
+    public FixedVector2(Vector2 vector)
+    {
+        _rawX = Mathf.RoundToInt(vector.x * UnitsPerFloat);
+        _rawY = Mathf.RoundToInt(vector.y * UnitsPerFloat);
+    }
+
+    /// <summary>
+    /// Converts to the Unity floating-point representation.
+    /// </summary>
+    public Vector2 ToVector2()
+    {
+        return new Vector2(_rawX / (float)UnitsPerFloat, _rawY / (float)UnitsPerFloat);
+    }
+
+    public static FixedVector2 FromVector2(Vector2 vector)
+    {
+        return new FixedVector2(vector);
+    }
+
+    public static FixedVector2 operator +(FixedVector2 a, FixedVector2 b)
+    {
+        return new FixedVector2(a._rawX + b._rawX, a._rawY + b._rawY);
+    }
+
+    public static FixedVector2 operator -(FixedVector2 a, FixedVector2 b)
+    {
+        return new FixedVector2(a._rawX - b._rawX, a._rawY - b._rawY);
+    }
+
+    public static FixedVector2 operator -(FixedVector2 value)
+    {
+        return new FixedVector2(-value._rawX, -value._rawY);
+    }
+
+    public override string ToString()
+    {
+        return $"({ToVector2().x:F3}, {ToVector2().y:F3})";
+    }
+
+    /// <summary>
+    /// Squared distance between two fixed vectors in squared fixed units.
+    /// </summary>
+    public static long DistanceSquared(FixedVector2 a, FixedVector2 b)
+    {
+        long dx = (long)a._rawX - b._rawX;
+        long dy = (long)a._rawY - b._rawY;
+        return dx * dx + dy * dy;
+    }
+}
+
+/// <summary>
+/// Axis-aligned box expressed in fixed-space coordinates.
+/// </summary>
+[Serializable]
+public struct HitBox
+{
+    public FixedVector2 Center;
+    public FixedVector2 HalfSize;
+
+    public HitBox(FixedVector2 center, FixedVector2 halfSize)
+    {
+        Center = center;
+        HalfSize = halfSize;
+    }
+
+    public int MinX => Center.RawX - HalfSize.RawX;
+    public int MaxX => Center.RawX + HalfSize.RawX;
+    public int MinY => Center.RawY - HalfSize.RawY;
+    public int MaxY => Center.RawY + HalfSize.RawY;
+
+    public bool Overlaps(HitBox other)
+    {
+        long dx = Math.Abs((long)Center.RawX - other.Center.RawX);
+        long dy = Math.Abs((long)Center.RawY - other.Center.RawY);
+        long limitX = (long)HalfSize.RawX + other.HalfSize.RawX;
+        long limitY = (long)HalfSize.RawY + other.HalfSize.RawY;
+        bool separated = dx > limitX || dy > limitY;
+        return !separated;
+    }
+
+    public bool Overlaps(HitCircle circle)
+    {
+        int clampedX = Mathf.Clamp(circle.Center.RawX, MinX, MaxX);
+        int clampedY = Mathf.Clamp(circle.Center.RawY, MinY, MaxY);
+
+        long dx = circle.Center.RawX - clampedX;
+        long dy = circle.Center.RawY - clampedY;
+        long radius = circle.Radius;
+        return (dx * dx + dy * dy) <= radius * radius;
+    }
+}
+
+/// <summary>
+/// Circle expressed in fixed-space coordinates.
+/// </summary>
+[Serializable]
+public struct HitCircle
+{
+    public FixedVector2 Center;
+    public int Radius; // in fixed units
+
+    public HitCircle(FixedVector2 center, int radius)
+    {
+        Center = center;
+        Radius = Mathf.Max(0, radius);
+    }
+
+    public bool Overlaps(HitCircle other)
+    {
+        long radii = (long)Radius + other.Radius;
+        return FixedVector2.DistanceSquared(Center, other.Center) <= radii * radii;
+    }
+
+    public bool Overlaps(HitBox box)
+    {
+        return box.Overlaps(this);
+    }
+}
+
+/// <summary>
+/// Core transform that stores a deterministic position alongside an optional planar rotation.
+/// </summary>
+[Serializable]
+public struct CoreTransform
+{
+    public FixedVector2 Position;
+    public float Rotation;
+
+    public CoreTransform(FixedVector2 position, float rotation = 0f)
+    {
+        Position = position;
+        Rotation = rotation;
+    }
+
+    public Vector3 ToVector3(float z = 0f)
+    {
+        Vector2 pos2 = Position.ToVector2();
+        return new Vector3(pos2.x, pos2.y, z);
+    }
+
+    public void ApplyTo(Transform transform)
+    {
+        if (!transform)
+        {
+            return;
+        }
+
+        Vector2 pos2 = Position.ToVector2();
+        Vector3 target = new Vector3(pos2.x, pos2.y, transform.position.z);
+        transform.position = target;
+        transform.rotation = Quaternion.Euler(0f, 0f, Rotation);
+    }
+
+    public static CoreTransform FromTransform(Transform transform)
+    {
+        if (!transform)
+        {
+            return default;
+        }
+
+        Vector3 pos = transform.position;
+        return new CoreTransform(new FixedVector2(pos.x, pos.y), transform.eulerAngles.z);
+    }
+}
+
+/// <summary>
+/// Keeps a Unity Transform in sync with a deterministic CoreTransform.
+/// </summary>
+[DisallowMultipleComponent]
+public sealed class TransformSync : MonoBehaviour
+{
+    [Tooltip("Deterministic transform data that should be mirrored to the Unity Transform.")]
+    public CoreTransform CoreTransform;
+
+    [Tooltip("Automatically initializes the BattleCore singleton if necessary.")]
+    public bool AutoInitializeBattleCore = true;
+
+    private void Awake()
+    {
+        if (AutoInitializeBattleCore)
+        {
+            BattleCore.Initialize();
+        }
+
+        /** Optional: Enable to copy from Unity Transform on Awake for editor previews. */
+        // CoreTransform = CoreTransform.FromTransform(transform);
+    }
+
+    private void LateUpdate()
+    {
+        CoreTransform.ApplyTo(transform);
+    }
+
+    public void SyncFromUnityTransform()
+    {
+        CoreTransform = CoreTransform.FromTransform(transform);
+    }
+}
+
+/// <summary>
+/// Internal runner that bridges Unity's Update loop to the deterministic ticker.
+/// </summary>
+internal sealed class BattleCoreTickerRunner : MonoBehaviour
+{
+    private Ticker _ticker;
+
+    public void Initialize(Ticker ticker)
+    {
+        _ticker = ticker;
+    }
+
+    private void Awake()
+    {
+        if (_ticker == null)
+        {
+            _ticker = BattleCore.Ticker;
+        }
+    }
+
+    private void Update()
+    {
+        _ticker?.Step(Time.deltaTime);
+    }
+}
+
+/// <summary>
+/// Fixed-rate ticker that publishes a tick event 60 times per second.
+/// </summary>
+public sealed class Ticker
+{
+    public const int TicksPerSecond = 60;
+
+    public event Action<int> OnTick;
+
+    private float _accumulator;
+    private int _tickCount;
+
+    public int TickCount => _tickCount;
+
+    public void Reset()
+    {
+        _accumulator = 0f;
+        _tickCount = 0;
+    }
+
+    public void Step(float deltaTime)
+    {
+        if (deltaTime <= 0f)
+        {
+            return;
+        }
+
+        _accumulator += deltaTime;
+        float interval = 1f / TicksPerSecond;
+
+        while (_accumulator >= interval)
+        {
+            _accumulator -= interval;
+            _tickCount++;
+            OnTick?.Invoke(_tickCount);
+        }
+    }
+}

--- a/Assets/Scripts/Generals/BattleCore.cs.meta
+++ b/Assets/Scripts/Generals/BattleCore.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cf9feb72c7b24696bf0e4bd991cac4da
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Generals/Interfaces.cs
+++ b/Assets/Scripts/Generals/Interfaces.cs
@@ -96,11 +96,13 @@ namespace ActInterfaces
 	{
 		void ApplyKnockback(Vector2 direction, float force);
 	}
-	public interface ISweepable
-	{
-		Vector2 DepenVector(LayerMask blockersMask, int maxIterations = 4, float skin = 0.03125F, float minEps = 0.001F, float maxTotal = 0.5F);
-		MoveResult SweepMove(Vector2 vec);
-	}
+        public interface ISweepable
+        {
+                Vector2 DepenVector(LayerMask blockersMask, int maxIterations = 4, float skin = 0.03125F, float minEps = 0.001F, float maxTotal = 0.5F);
+                void SweepMove(FixedVector2 vec);
+                MoveResult LastMoveResult { get; }
+                int LastProcessedTick { get; }
+        }
 	public interface IMovable
 	{
 		Vector2 LastMoveDir { get; }

--- a/Assets/Scripts/Generals/KinematicMotor2D.cs
+++ b/Assets/Scripts/Generals/KinematicMotor2D.cs
@@ -1,24 +1,30 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using UnityEngine;
 using ActInterfaces;
 
 [Serializable]
 public struct CollisionPolicy
 {
-	public LayerMask wallsMask;    
-	public LayerMask enemyMask;  
-	public bool enemyAsBlocker;    
-	public float radius;            
-	public float skin;               
-	public bool allowWallSlide;      
+    public LayerMask wallsMask;
+    public LayerMask enemyMask;
+    public bool enemyAsBlocker;
+    public float radius;
+    public float skin;
+    public bool allowWallSlide;
 }
 
 public struct MoveResult
 {
-	public Vector2 actualDelta;
-	public bool hitWall, hitEnemy;
-	public Transform hitTransform;
-	public Vector2 hitNormal;
+    public FixedVector2 actualDelta;
+    public bool hitWall, hitEnemy;
+    public Transform hitTransform;
+    public Vector2 hitNormal;
+
+    /// <summary>
+    /// Helper accessor for legacy call sites that expect a float Vector2 delta.
+    /// </summary>
+    public Vector2 ActualDeltaVector => actualDelta.ToVector2();
 }
 
 [DisallowMultipleComponent]
@@ -26,274 +32,406 @@ public struct MoveResult
 [RequireComponent(typeof(Collider2D))]
 public class KinematicMotor2D : MonoBehaviour, ISweepable
 {
-	[Header("Defaults")]
-	public CollisionPolicy defaultPolicy = new()
-	{
-		wallsMask = 0,
-		enemyMask = 0,
-		enemyAsBlocker = true,
-		radius = 0.5f,
-		skin = 0.125f,
-		allowWallSlide = true
-	};
+    [Header("Defaults")]
+    public CollisionPolicy defaultPolicy = new()
+    {
+        wallsMask = 0,
+        enemyMask = 0,
+        enemyAsBlocker = true,
+        radius = 0.5f,
+        skin = 0.125f,
+        allowWallSlide = true
+    };
 
-	Rigidbody2D rb;
-	Collider2D col;
-	CollisionPolicy current;
-	//bool movable = true;
+    private Rigidbody2D rb;
+    private Collider2D col;
+    private CollisionPolicy current;
 
-	void Awake()
-	{
-		rb = GetComponent<Rigidbody2D>();
-		rb.bodyType = RigidbodyType2D.Kinematic;
-		rb.gravityScale = 0f;
-		current = defaultPolicy;
-		col = rb.GetComponent<Collider2D>();
-		Debug.Log(col.isTrigger);
-	}
+    private readonly List<FixedVector2> _pendingMoves = new();
+    private CoreTransform _coreTransform;
+    private MoveResult _lastMoveResult;
+    private int _lastProcessedTick;
+    private bool _needsTransformSync;
 
-	public IDisposable With(in CollisionPolicy overridePolicy)
-	{
-		var prev = current;
-		current = overridePolicy;
-		return new Scope(() => current = prev);
-	}
-	sealed class Scope : IDisposable { readonly Action onDispose; public Scope(Action a) { onDispose = a; } public void Dispose() { onDispose?.Invoke(); } }
-	// [RULE: Depenetrate/MTV] 시작 겹침 탈출(벽+적 모두, 최소 이탈 벡터)
-	public Vector2 RemoveNormalComponent(Vector2 vector, LayerMask mask, MoveResult result)
-	{
-		Vector2 vfinal = vector;
-		// 1) 벽 우선
-		var maskHit = Physics2D.CircleCastAll((Vector2)transform.position, current.radius, vector.normalized, vector.magnitude, mask);
-		foreach (var hit in maskHit)
-		{
-			if(mask == current.enemyMask && !current.enemyAsBlocker)
-			{
-				//Debug.Log("Hello again");
-				vfinal = vector;
-			}
-			else if (hit.collider)
-			{
-				//법선 성분을 무효로 한다
-				result.hitWall = true;
-				result.hitTransform = hit.transform;
-				result.hitNormal = hit.normal.normalized;
+    private void Awake()
+    {
+        BattleCore.Initialize();
 
-				Vector2 n = hit.normal.normalized;
-				Vector2 v = vfinal;
-				float dot = Vector2.Dot(v, n);
-				var hitPt = hit.point;
-				if (Mathf.Abs(dot) > 0f) //Abs?
-				{
-					v -= dot * n;            // v' = v - max(0,dot) * n
-					vfinal = v; 			//벡터 연산을 중첩시키기 위해서 vfinal에 대입
-				}
-			}
-		}
-		return vfinal;
-	}
-	public MoveResult SweepMove(Vector2 desiredDelta)
-	{
-		var result = new MoveResult { actualDelta = Vector2.zero };
-		if (desiredDelta.sqrMagnitude <= 0f) return result;
-		Vector2 origin = transform.position;
-		float remaining = desiredDelta.magnitude;
-		Vector2 wishDir = desiredDelta.normalized;
+        rb = GetComponent<Rigidbody2D>();
+        rb.bodyType = RigidbodyType2D.Kinematic;
+        rb.gravityScale = 0f;
+        current = defaultPolicy;
+        col = rb.GetComponent<Collider2D>();
+        Debug.Log(col.isTrigger);
 
-		const int kMaxSlideIters = 4;
-		int iters = 0;
+        _coreTransform = CoreTransform.FromTransform(transform);
+        _needsTransformSync = true;
+    }
 
-		while (remaining > 1e-5f && iters++ < kMaxSlideIters)
-		{
-			Vector2 vfinal = wishDir * remaining;
-			// 1) 벽 우선
-			//vfinal = wishDir * remaining;
-			vfinal = RemoveNormalComponent(vfinal, current.wallsMask, result);
-			// 2) 적 차단(기본값 true). “겹치기 금지” 정책 유지
-			vfinal = RemoveNormalComponent(vfinal, current.enemyMask, result);
-			//↓RemoveComponent를 2번 수행했을 때 제거되는 성분이 있다면(즉, 벡터가 수평도 수직도 아니라서 어느 한쪽의 접선이 다른 쪽을 넘을 경우) 이동을 무효로
-			if(vfinal != RemoveNormalComponent(vfinal, current.wallsMask, result) || vfinal != RemoveNormalComponent(vfinal, current.enemyMask, result))
-			{
-				//vfinal = Vector2.zero;
-				break;
-			}
-			else if (vfinal.sqrMagnitude > 1e-6f)            // 접선(or 바깥) 성분이 남아 있으면 계속
-			{
-				wishDir = vfinal.normalized;
-				remaining = vfinal.magnitude;
-				//continue;                           // 같은 프레임 내 다음 캐스트로
-			}
-			// 더 진행할 수 없으면 그 프레임 종료
-			else
-			{
-				break;
-			}
-			// 실제 이동을 여기서 수행, 이동할 수 없는 이유가 있다면 위의 분기점에서 break가 호출되어 실행되지 않음
-			MoveDiscrete(vfinal);
-			remaining = 0f;
-		}
-		result.actualDelta = (Vector2)transform.position - origin;
-		return result;
-	}
+    private void OnEnable()
+    {
+        BattleCore.Ticker.OnTick += HandleTick;
+    }
 
-	void MoveDiscrete(Vector2 delta)
-	{
-		if (delta.sqrMagnitude <= 0f) return;
-		if (rb) rb.MovePosition((Vector2)transform.position + delta);
-		else transform.position += (Vector3)delta;
-	}
+    private void OnDisable()
+    {
+        BattleCore.Ticker.OnTick -= HandleTick;
+    }
 
-	public CollisionPolicy CurrentPolicy => current;
-	/// <summary>
-	/// 현재 위치에서 Blocker(환경)들과의 겹침을 검사하여
-	/// "한 번"의 최소 이동 벡터(MTD)를 계산해 반환합니다.
-	/// - 실제 위치 이동은 하지 않습니다. (Depenetration()이 적용 담당)
-	/// - 합성형(여러 침투벡터 합산) 방식으로 단일 MTD를 구합니다.
-	/// </summary>
-	/// <param name="blockersMask">Walls&Obstacles (+ 선택적으로 Enemy)</param>
-	/// <param name="maxIterations">미사용(반복은 Depenetration에서 수행). 시그니처 유지용.</param>
-	/// <param name="skin">스킨 마진. 기본 0.03125(=2^-5)</param>
-	/// <param name="minEps">보정 문턱. 이보다 작으면 0으로 간주</param>
-	/// <param name="maxTotal">총 보정 상한(Depenetration에서 사용). 시그니처 유지용.</param>
-	/// <returns>이번 스텝에서 적용할 단일 MTD(보정 벡터). 없으면 (0,0)</returns>
-	public Vector2 DepenVector(LayerMask blockersMask, int maxIterations = 4, float skin = 0.125f, float minEps = 0.001f, float maxTotal = 0.5f)
-	{
-		// 안전 체크
-		if (rb == null || col == null)
-			return Vector2.zero;
+    private void HandleTick(int tick)
+    {
+        ProcessPendingMoves();
+        _lastProcessedTick = tick;
+    }
 
-		// ContactFilter2D 구성: Blocker 레이어만, Trigger 무시
-		ContactFilter2D filter = new() { useLayerMask = true };
-		filter.SetLayerMask(blockersMask);
-		filter.useTriggers = false;
+    private void LateUpdate()
+    {
+        if (!_needsTransformSync)
+        {
+            return;
+        }
 
-		// 겹침 수집 버퍼 (필드 추가 금지 조건에 맞춰 지역 배열 사용)
-		Collider2D[] hits = new Collider2D[16];
-		int count = col.Overlap(filter, hits);
-		if (count <= 0)
-			return Vector2.zero;
+        // Mirror the deterministic CoreTransform to the Unity Transform every frame when movement occurred.
+        _coreTransform.ApplyTo(transform);
+        _needsTransformSync = false;
+    }
 
-		// --- 합성형 MTD 누적 ---
-		Vector2 accum = Vector2.zero;
-		int validContacts = 0;
+    public IDisposable With(in CollisionPolicy overridePolicy)
+    {
+        var prev = current;
+        current = overridePolicy;
+        return new Scope(() => current = prev);
+    }
 
-		for (int i = 0; i < count; i++)
-		{
-			var other = hits[i];
-			if (!other) continue;
+    private sealed class Scope : IDisposable
+    {
+        private readonly Action onDispose;
 
-			// 현재 Player 콜라이더(col) 기준으로 거리/법선 계산
-			// d.isOverlapped == true 이면 d.distance 는 "겹침 해소에 필요한 양(>0)"
-			ColliderDistance2D d = col.Distance(other);
-			if (!d.isOverlapped) continue;
+        public Scope(Action action)
+        {
+            onDispose = action;
+        }
 
-			// 누적(법선 * 거리) — 합성형
-			accum += d.normal * d.distance;
-			validContacts++;
-		}
+        public void Dispose()
+        {
+            onDispose?.Invoke();
+        }
+    }
 
-		if (validContacts == 0)
-			return Vector2.zero;
+    /// <summary>
+    /// Queue a deterministic movement request that will resolve on the next BattleCore tick.
+    /// </summary>
+    /// <param name="desiredDelta">Desired displacement expressed in fixed units.</param>
+    public void SweepMove(FixedVector2 desiredDelta)
+    {
+        _pendingMoves.Add(desiredDelta);
+    }
 
-		float mag = accum.magnitude;
-		if (mag < minEps)
-			return Vector2.zero;
+    /// <summary>
+    /// Last resolved move result (updated after each tick).
+    /// </summary>
+    public MoveResult LastMoveResult => _lastMoveResult;
 
-		// 스킨 마진을 더해 "살짝 더" 바깥으로 밀어냄
-		Vector2 mtd = (accum / mag) * (mag + skin);
+    /// <summary>
+    /// Tick index corresponding to <see cref="LastMoveResult"/>.
+    /// </summary>
+    public int LastProcessedTick => _lastProcessedTick;
 
-		/*** 디버그(기본 비활성, 필요시 주석 해제)
-		// 개별 접촉 법선 시각화
-		for (int i = 0; i < count; i++)
-		{
-			var other = hits[i];
-			if (!other) continue;
-			var d = col.Distance(other);
-			if (!d.isOverlapped) continue;
+    private Vector2 RemoveNormalComponent(Vector2 vector, LayerMask mask, ref MoveResult result)
+    {
+        Vector2 vfinal = vector;
+        float magnitude = vector.magnitude;
+        if (magnitude <= 0f)
+        {
+            return Vector2.zero;
+        }
 
-			Vector2 p = rb.position; // 대략적인 기준점
-			Debug.DrawRay(p, d.normal * Mathf.Max(d.distance, 0.02f), Color.cyan, 0.02f);
-		}
-		// 최종 MTD(주황)
-		Debug.DrawRay(rb.position, mtd, new Color(1f, 0.5f, 0f), 0.02f);
-		***/
+        Vector2 origin = _coreTransform.Position.ToVector2();
+        var maskHit = Physics2D.CircleCastAll(origin, current.radius, vector.normalized, magnitude, mask);
+        foreach (var hit in maskHit)
+        {
+            if (!hit.collider)
+            {
+                continue;
+            }
 
-		return mtd;
-	}
+            if (mask == current.enemyMask && !current.enemyAsBlocker)
+            {
+                continue;
+            }
 
-	/// <summary>
-	/// DepenVector()를 반복 호출하여 실제로 위치 보정(MovePosition)을 수행합니다.
-	/// - 최대 반복 4회
-	/// - 스킨 0.03125
-	/// - 문턱 0.001
-	/// - 총 보정 상한 0.5m
-	/// - 마스크: current.wallsMask | (current.enemyAsBlocker ? current.enemyMask : 0)
-	/// </summary>
-	public void Depenetration()
-	{
-		if (rb == null || col == null)
-			return;
+            if (mask == current.enemyMask)
+            {
+                result.hitEnemy = true;
+            }
+            else
+            {
+                result.hitWall = true;
+            }
 
-		// 1) Blocker 마스크 구성
-		LayerMask blockersMask = current.wallsMask;
-		if (current.enemyAsBlocker)
-			blockersMask |= current.enemyMask;
+            result.hitTransform = hit.transform;
+            result.hitNormal = hit.normal.normalized;
 
-		// 2) 반복 보정 파라미터(요구사항 고정값 반영)
-		int maxIterations = 4;
-		float skin = 0.125f;
-		float minEps = 0.001f;
-		float maxTotal = 0.5f;
+            Vector2 n = hit.normal.normalized;
+            float dot = Vector2.Dot(vfinal, n);
+            if (Mathf.Abs(dot) > 0f)
+            {
+                vfinal -= dot * n;
+            }
+        }
 
-		Vector2 total = Vector2.zero;
+        return vfinal;
+    }
 
-		for (int it = 0; it < maxIterations; it++)
-		{
-			// 현재 위치에서 "한 번"의 MTD 계산
-			Vector2 mtd = DepenVector(blockersMask, maxIterations, skin, minEps, maxTotal);
-			if (mtd.sqrMagnitude <= (minEps * minEps))
-				break;
+    private void ProcessPendingMoves()
+    {
+        if (_pendingMoves.Count == 0)
+        {
+            _lastMoveResult = default;
+            return;
+        }
 
-			// 총 상한 체크 (안전장치)
-			if ((total + mtd).magnitude > maxTotal)
-			{
-				// 필요시 로그를 남기세요 (지오메트리/레이어 설정 문제일 수 있습니다)
-				// Debug.LogWarning($"Depenetration exceeded maxTotal({maxTotal}). Clamping.");
-				// 상한을 넘지 않도록 mtd를 클램프
-				Vector2 dir = mtd.normalized;
-				float remain = Mathf.Max(0f, maxTotal - total.magnitude);
-				mtd = dir * remain;
-			}
+        MoveResult aggregated = default;
+        FixedVector2 totalActual = new(0, 0);
 
-			// 실제 위치 보정 — MovePosition 사용(요구사항 #3)
-			rb.MovePosition(rb.position + mtd);
+        for (int i = 0; i < _pendingMoves.Count; i++)
+        {
+            FixedVector2 requested = _pendingMoves[i];
+            MoveResult step = ExecuteSweep(requested);
+            totalActual += step.actualDelta;
+            aggregated.hitWall |= step.hitWall;
+            aggregated.hitEnemy |= step.hitEnemy;
+            if (!aggregated.hitTransform && step.hitTransform)
+            {
+                aggregated.hitTransform = step.hitTransform;
+            }
 
-			total += mtd;
+            if (step.hitNormal != Vector2.zero)
+            {
+                aggregated.hitNormal = step.hitNormal;
+            }
+        }
 
-			// 총 상한에 도달하면 중단
-			if (Mathf.Abs(maxTotal - total.magnitude) <= 1e-5f)
-				break;
-		}
+        aggregated.actualDelta = totalActual;
+        _lastMoveResult = aggregated;
+        _pendingMoves.Clear();
+    }
 
-		/*** 디버그(기본 비활성, 필요시 주석 해제)
-		if (total.sqrMagnitude > 0f)
-		{
-			Debug.DrawRay(rb.position - total, total, Color.yellow, 0.05f); // 전체 보정(노랑)
-		}
-		***/
-	}
+    private MoveResult ExecuteSweep(FixedVector2 desiredDelta)
+    {
+        MoveResult result = new()
+        {
+            actualDelta = new FixedVector2(0, 0)
+        };
 
-	/*
-	// 참고: "최심 침투 우선형" 알고리즘 개요(요구사항 4 — 실제 구현 X, 주석만)
-	//
-	// for (it=0; it<maxIterations; it++):
-	//   overlaps = OverlapCollider(...)
-	//   if overlaps.empty: break
-	//   pick = argmax(overlaps, by d.distance)   // 가장 깊은 침투 1개 선택
-	//   mtd  = pick.normal * (pick.distance + skin)
-	//   rb.MovePosition(rb.position + mtd)
-	//   // 다음 반복에서 겹침 재평가
-	//
-	// 장점: 안정적(최심 해소부터) / 단점: 반복 횟수가 늘 수 있음
-	*/
+        Vector2 desired = desiredDelta.ToVector2();
+        if (desired.sqrMagnitude <= 0f)
+        {
+            return result;
+        }
+
+        FixedVector2 originFixed = _coreTransform.Position;
+        float remaining = desired.magnitude;
+        Vector2 wishDir = desired.normalized;
+
+        const int kMaxSlideIters = 4;
+        int iters = 0;
+
+        while (remaining > 1e-5f && iters++ < kMaxSlideIters)
+        {
+            Vector2 vfinal = wishDir * remaining;
+            vfinal = RemoveNormalComponent(vfinal, current.wallsMask, ref result);
+            vfinal = RemoveNormalComponent(vfinal, current.enemyMask, ref result);
+
+            MoveResult wallProbe = result;
+            Vector2 checkWalls = RemoveNormalComponent(vfinal, current.wallsMask, ref wallProbe);
+            MoveResult enemyProbe = result;
+            Vector2 checkEnemies = RemoveNormalComponent(vfinal, current.enemyMask, ref enemyProbe);
+            if (vfinal != checkWalls || vfinal != checkEnemies)
+            {
+                break;
+            }
+            else if (vfinal.sqrMagnitude > 1e-6f)
+            {
+                wishDir = vfinal.normalized;
+                remaining = vfinal.magnitude;
+            }
+            else
+            {
+                break;
+            }
+
+            MoveDiscrete(new FixedVector2(vfinal));
+            remaining = 0f;
+        }
+
+        result.actualDelta = _coreTransform.Position - originFixed;
+        return result;
+    }
+
+    private void MoveDiscrete(FixedVector2 delta)
+    {
+        Vector2 deltaVector = delta.ToVector2();
+        if (deltaVector.sqrMagnitude <= 0f)
+        {
+            return;
+        }
+
+        _coreTransform.Position += delta;
+        _needsTransformSync = true;
+    }
+
+    public CollisionPolicy CurrentPolicy => current;
+
+    /// <summary>
+    /// 현재 위치에서 Blocker(환경)들과의 겹침을 검사하여
+    /// "한 번"의 최소 이동 벡터(MTD)를 계산해 반환합니다.
+    /// - 실제 위치 이동은 하지 않습니다. (Depenetration()이 적용 담당)
+    /// - 합성형(여러 침투벡터 합산) 방식으로 단일 MTD를 구합니다.
+    /// </summary>
+    public Vector2 DepenVector(LayerMask blockersMask, int maxIterations = 4, float skin = 0.125f, float minEps = 0.001f, float maxTotal = 0.5f)
+    {
+        if (rb == null || col == null)
+        {
+            return Vector2.zero;
+        }
+
+        ContactFilter2D filter = new() { useLayerMask = true };
+        filter.SetLayerMask(blockersMask);
+        filter.useTriggers = false;
+
+        Collider2D[] hits = new Collider2D[16];
+        int count = col.Overlap(filter, hits);
+        if (count <= 0)
+        {
+            return Vector2.zero;
+        }
+
+        Vector2 accum = Vector2.zero;
+        int validContacts = 0;
+
+        for (int i = 0; i < count; i++)
+        {
+            var other = hits[i];
+            if (!other)
+            {
+                continue;
+            }
+
+            ColliderDistance2D d = col.Distance(other);
+            if (!d.isOverlapped)
+            {
+                continue;
+            }
+
+            accum += d.normal * d.distance;
+            validContacts++;
+        }
+
+        if (validContacts == 0)
+        {
+            return Vector2.zero;
+        }
+
+        float mag = accum.magnitude;
+        if (mag < minEps)
+        {
+            return Vector2.zero;
+        }
+
+        Vector2 mtd = (accum / mag) * (mag + skin);
+
+        /*** Debug helper (disabled by default). Enable for MTV visualization. */
+        //for (int i = 0; i < count; i++)
+        //{
+        //    var other = hits[i];
+        //    if (!other) continue;
+        //    var d = col.Distance(other);
+        //    if (!d.isOverlapped) continue;
+        //    Vector2 p = rb.position;
+        //    Debug.DrawRay(p, d.normal * Mathf.Max(d.distance, 0.02f), Color.cyan, 0.02f);
+        //}
+        //Debug.DrawRay(rb.position, mtd, new Color(1f, 0.5f, 0f), 0.02f);
+        /***/
+
+        return mtd;
+    }
+
+    /// <summary>
+    /// DepenVector()를 반복 호출하여 실제로 위치 보정(MovePosition)을 수행합니다.
+    /// - 최대 반복 4회
+    /// - 스킨 0.03125
+    /// - 문턱 0.001
+    /// - 총 보정 상한 0.5m
+    /// - 마스크: current.wallsMask | (current.enemyAsBlocker ? current.enemyMask : 0)
+    /// </summary>
+    public void Depenetration()
+    {
+        if (rb == null || col == null)
+        {
+            return;
+        }
+
+        LayerMask blockersMask = current.wallsMask;
+        if (current.enemyAsBlocker)
+        {
+            blockersMask |= current.enemyMask;
+        }
+
+        int maxIterations = 4;
+        float skin = 0.125f;
+        float minEps = 0.001f;
+        float maxTotal = 0.5f;
+
+        Vector2 total = Vector2.zero;
+
+        for (int it = 0; it < maxIterations; it++)
+        {
+            Vector2 mtd = DepenVector(blockersMask, maxIterations, skin, minEps, maxTotal);
+            if (mtd.sqrMagnitude <= (minEps * minEps))
+            {
+                break;
+            }
+
+            if ((total + mtd).magnitude > maxTotal)
+            {
+                Vector2 dir = mtd.normalized;
+                float remain = Mathf.Max(0f, maxTotal - total.magnitude);
+                mtd = dir * remain;
+            }
+
+            rb.MovePosition(rb.position + mtd);
+
+            total += mtd;
+
+            if (Mathf.Abs(maxTotal - total.magnitude) <= 1e-5f)
+            {
+                break;
+            }
+        }
+
+        _coreTransform.Position = new FixedVector2(rb.position);
+        _needsTransformSync = true;
+
+        /*** Optional debug ray (disabled by default). */
+        //if (total.sqrMagnitude > 0f)
+        //{
+        //    Debug.DrawRay(rb.position - total, total, Color.yellow, 0.05f);
+        //}
+        /***/
+    }
 }
+
+/*
+// 참고: "최심 침투 우선형" 알고리즘 개요(요구사항 4 — 실제 구현 X, 주석만)
+//
+// for (it=0; it<maxIterations; it++):
+//   overlaps = OverlapCollider(...)
+//   if overlaps.empty: break
+//   pick = argmax(overlaps, by d.distance)   // 가장 깊은 침투 1개 선택
+//   mtd  = pick.normal * (pick.distance + skin)
+//   rb.MovePosition(rb.position + mtd)
+//   // 다음 반복에서 겹침 재평가
+//
+// 장점: 안정적(최심 해소부터) / 단점: 반복 횟수가 늘 수 있음
+*/

--- a/Assets/Scripts/PlayerScripts/PlayerLocomotion.cs
+++ b/Assets/Scripts/PlayerScripts/PlayerLocomotion.cs
@@ -3,43 +3,40 @@ using UnityEngine;
 
 public class PlayerLocomotion : MonoBehaviour, IMovable, IPullable
 {
-    [SerializeField] private Rigidbody2D rb;          // Kinematic º»Ã¼
-    public Vector2 LastMoveDir { get; private set; }
-    // KnockbackÀº Kinematic¿¡¼­ ¹°¸®¼Óµµ°¡ ¾Æ´Ñ "Ãß°¡ º¯À§"·Î Ã³¸®
-    Vector2 _knockbackBudget;                         // ÀÌ¹ø ÇÁ·¹ÀÓ¿¡ ¼ÒºñÇÒ Ãß°¡ º¯À§(¿ùµå ÁÂÇ¥)
-
-    /// <summary>
-    /// IMovable: ÀÇµµ(¹æÇâ¡¤¼Óµµ)¸¦ ´ÜÀÏ ½ºÀ¬¿ë "µ¨Å¸"·Î È¯»êÇÏ¿© Motor·Î Àü´ŞÇÕ´Ï´Ù.
-    /// - ÀÌµ¿ °áÁ¤Àº »óÀ§¿¡¼­(¼Óµµ/ÀÔ·Â), Ãæµ¹-Àı´ÜÀº Motor¿¡¼­.
-    /// - ÇÁ·¹ÀÓ´ç ´Ü ÇÑ ¹ø È£ÃâµÇµµ·Ï ÄÁÆ®·Ñ·¯(Update)¿¡¼­¸¸ È£ÃâÇÏ¼¼¿ä.
-    /// </summary>
-    public void Move(Vector2 direction, Rigidbody2D rbArg, float speed)
-    {
-        // ¹æÇâ Á¤±ÔÈ­ ¹× µ¨Å¸ »êÃâ
-        Vector2 dir = direction.sqrMagnitude > 1e-4f ? direction.normalized : Vector2.zero;
-        Vector2 delta = Mathf.Max(0f, speed) * Time.deltaTime * dir;
-        // Knockback Ãß°¡ º¯À§´Â °°Àº ÇÁ·¹ÀÓ¿¡ ¼Òºñ ÈÄ 0À¸·Î
-        if (_knockbackBudget.sqrMagnitude > 0f)
-        {
+    FixedVector2 _knockbackBudget;                         // Ì¹ Ó¿ Òº ß° ( Ç¥)
+        float distancePerTick = Mathf.Max(0f, speed) / Ticker.TicksPerSecond;
+        Vector2 delta = distancePerTick * dir;
+        FixedVector2 fixedDelta = new(delta);
+        if (_knockbackBudget.RawX != 0 || _knockbackBudget.RawY != 0)
+            fixedDelta += _knockbackBudget;
+            _knockbackBudget = new FixedVector2(0, 0);
+        var motor = GetComponentInParent<KinematicMotor2D>();
+        if (!motor) return;
+        motor.Depenetration();
+        motor.SweepMove(fixedDelta);
+        motor.Depenetration();
+        LastMoveDir = direction;
+        float distancePerTick = Mathf.Max(0f, force) / Ticker.TicksPerSecond;
+        _knockbackBudget += new FixedVector2(dir * distancePerTick);
             delta += _knockbackBudget;
             _knockbackBudget = Vector2.zero;
         }
-		// ÀÇµµ ¹æÇâÀ» ¼±È£ ¹æÇâÀ¸·Î ÇÏ¿© °ãÄ§ Ã»¼Ò(¸ğ¼­¸® ¶ô ¹æÁö)  // :contentReference[oaicite:12]{index=12}
+		// ì˜ë„ ë°©í–¥ì„ ì„ í˜¸ ë°©í–¥ìœ¼ë¡œ í•˜ì—¬ ê²¹ì¹¨ ì²­ì†Œ(ëª¨ì„œë¦¬ ë½ ë°©ì§€)  // :contentReference[oaicite:12]{index=12}
 		var motor = GetComponentInParent<KinematicMotor2D>();
 		if (!motor) return;
 		//motor.RemoveComponent();
 		motor.Depenetration();
-        // ´ÜÀÏ ½ºÀ¬ ÀÌµ¿(Ãæµ¹·Î Àı´Ü/½½¶óÀÌµå´Â Motor Á¤Ã¥¿¡ µû¸§)      // :contentReference[oaicite:13]{index=13}
+        // ë‹¨ì¼ ìŠ¤ìœ• ì´ë™(ì¶©ëŒë¡œ ì ˆë‹¨/ìŠ¬ë¼ì´ë“œëŠ” Motor ì •ì±…ì— ë”°ë¦„)      // :contentReference[oaicite:13]{index=13}
         var res = motor.SweepMove(delta);
 		motor.Depenetration();
-        // ¸¶Áö¸· ½ÇÁ¦ ÀÌµ¿ º¤ÅÍ ±â·Ï(¿øÇÑ´Ù¸é ½ÇÁ¦ ¼Óµµ µî 2Â÷ ÆÄ»ı °¡´É)
+        // ë§ˆì§€ë§‰ ì‹¤ì œ ì´ë™ ë²¡í„° ê¸°ë¡(ì›í•œë‹¤ë©´ ì‹¤ì œ ì†ë„ ë“± 2ì°¨ íŒŒìƒ ê°€ëŠ¥)
         LastMoveDir = direction;//motor.LastMoveVector;
     }
 
     /// <summary>
-    /// IPullable: Kinematic¿¡¼­´Â velocity º¯°æÀÌ ¹«ÀÇ¹ÌÇÏ¹Ç·Î,
-    /// "Áï½Ã ÇÑ ¹ø ¹Ğ¸®´Â Ãß°¡ º¯À§" ¿¹»êÀ¸·Î ÀüÈ¯ÇØ ´ÙÀ½ Move¿¡¼­ ¼ÒºñÇÕ´Ï´Ù.
-    /// force ´ÜÀ§´Â '°Å¸®'·Î °£ÁÖ(ÇÊ¿ä ½Ã °¨¼è/½Ã°£±â¹İÀ¸·Î È®Àå °¡´É).
+    /// IPullable: Kinematicì—ì„œëŠ” velocity ë³€ê²½ì´ ë¬´ì˜ë¯¸í•˜ë¯€ë¡œ,
+    /// "ì¦‰ì‹œ í•œ ë²ˆ ë°€ë¦¬ëŠ” ì¶”ê°€ ë³€ìœ„" ì˜ˆì‚°ìœ¼ë¡œ ì „í™˜í•´ ë‹¤ìŒ Moveì—ì„œ ì†Œë¹„í•©ë‹ˆë‹¤.
+    /// force ë‹¨ìœ„ëŠ” 'ê±°ë¦¬'ë¡œ ê°„ì£¼(í•„ìš” ì‹œ ê°ì‡ /ì‹œê°„ê¸°ë°˜ìœ¼ë¡œ í™•ì¥ ê°€ëŠ¥).
     /// </summary>
     public void ApplyKnockback(Vector2 direction, float force)
     {
@@ -47,5 +44,5 @@ public class PlayerLocomotion : MonoBehaviour, IMovable, IPullable
         _knockbackBudget += dir * Mathf.Max(0f, force);
     }
 
-    // (Âü°í) ±âÁ¸ Jump/CoroutineÀº ±×´ë·Î µÎµÇ, ½ÇÁ¦ ¼öÁ÷ ÀÌµ¿ÀÌ ÇÊ¿äÇÏ¸é º°µµ ¸ğÅÍ/·¹ÀÌ¾î·Î ºĞ¸® ±ÇÀå -> Jump¸¦ °è¼Ó »ç¿ëÇØ¾ß ÇÒÁö ¸ğ¸£°ÚÀ½
+    // (ì°¸ê³ ) ê¸°ì¡´ Jump/Coroutineì€ ê·¸ëŒ€ë¡œ ë‘ë˜, ì‹¤ì œ ìˆ˜ì§ ì´ë™ì´ í•„ìš”í•˜ë©´ ë³„ë„ ëª¨í„°/ë ˆì´ì–´ë¡œ ë¶„ë¦¬ ê¶Œì¥ -> Jumpë¥¼ ê³„ì† ì‚¬ìš©í•´ì•¼ í• ì§€ ëª¨ë¥´ê² ìŒ
 }


### PR DESCRIPTION
## Summary
- queue FixedVector2 sweep requests in KinematicMotor2D, resolve them on the BattleCore ticker, and drive Unity transforms from the deterministic CoreTransform
- extend the ISweepable contract and update PlayerLocomotion to supply per-tick movement and knockback budgets in fixed units
- shift the dash coroutine to await ticker results and consume the actual fixed displacement when progressing dash distance

## Testing
- not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ec506d9b74832caacea92f456dd715