### PR TITLE
Add deterministic entity data and world orchestration layer

### DIFF
--- a/Assets/Scripts/Generals/EntityData.cs
+++ b/Assets/Scripts/Generals/EntityData.cs
@@ -1,0 +1,220 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// Represents a deterministic identifier for entities managed by <see cref="TheWorld"/>.
+/// Using a dedicated struct avoids accidental misuse of raw integers and keeps the
+/// simulation layer free from implicit conversions.
+/// </summary>
+[Serializable]
+public readonly struct EntityId : IEquatable<EntityId>, IComparable<EntityId>
+{
+	/// <summary>
+	/// Sentinel value representing an invalid or unassigned entity reference.
+	/// </summary>
+	public static readonly EntityId Invalid = new(-1);
+
+	[SerializeField]
+	private readonly int _value;
+
+	public EntityId(int value)
+	{
+		_value = value;
+	}
+
+	/// <summary>
+	/// Raw integer handle used for deterministic array indexing. Intended for serialization only.
+	/// </summary>
+	public int Value => _value;
+
+	public bool IsValid => _value >= 0;
+
+	public bool Equals(EntityId other)
+	{
+		return _value == other._value;
+	}
+
+	public override bool Equals(object obj)
+	{
+		return obj is EntityId other && Equals(other);
+	}
+
+	public override int GetHashCode()
+	{
+		return _value;
+	}
+
+	public int CompareTo(EntityId other)
+	{
+		return _value.CompareTo(other._value);
+	}
+
+	public static bool operator ==(EntityId left, EntityId right)
+	{
+		return left.Equals(right);
+	}
+
+	public static bool operator !=(EntityId left, EntityId right)
+	{
+		return !left.Equals(right);
+	}
+
+	public override string ToString()
+	{
+		return IsValid ? $"EntityId({_value})" : "EntityId(Invalid)";
+	}
+}
+
+/// <summary>
+/// Atomic, fully deterministic state for a single simulation entity. The struct contains
+/// both persistent attributes (team, stats) and transient integrators (velocity, impulse).
+/// All numeric fields rely on fixed-point arithmetic to guarantee reproducibility across
+/// different hardware.
+/// </summary>
+[Serializable]
+public struct EntityData
+{
+	/// <summary>
+	/// Identifier assigned by <see cref="TheWorld"/>.
+	/// </summary>
+	[SerializeField]
+	public EntityId Id;
+
+	/// <summary>
+	/// Whether the slot is currently owned by a live entity.
+	/// </summary>
+	[SerializeField]
+	public bool IsActive;
+
+	/// <summary>
+	/// World-space position expressed in fixed units.
+	/// </summary>
+	[SerializeField]
+	public FixedVector2 Position;
+
+	/// <summary>
+	/// Per-tick velocity delta in fixed units.
+	/// </summary>
+	[SerializeField]
+	public FixedVector2 Velocity;
+
+	/// <summary>
+	/// Additional forces accumulated during the tick. Cleared automatically once applied.
+	/// </summary>
+	[SerializeField]
+	public FixedVector2 ExternalImpulse;
+
+	/// <summary>
+	/// Facing direction stored as milli-degrees (1000 equals one real degree).
+	/// </summary>
+	[SerializeField]
+	public int FacingMilliDegrees;
+
+	/// <summary>
+	/// Entity faction/team identifier. Systems use it for deterministic filtering.
+	/// </summary>
+	[SerializeField]
+	public int TeamId;
+
+	/// <summary>
+	/// Hit points represented as fixed raw units (avoid floats for determinism).
+	/// </summary>
+	[SerializeField]
+	public int HitPoints;
+
+	/// <summary>
+	/// Maximum hit points for clamping purposes.
+	/// </summary>
+	[SerializeField]
+	public int MaxHitPoints;
+
+	/// <summary>
+	/// Optional custom flags used by deterministic systems (bit-packed state machine).
+	/// </summary>
+	[SerializeField]
+	public uint StateFlags;
+
+	/// <summary>
+	/// Size descriptor primarily consumed by deterministic collision systems.
+	/// </summary>
+	[SerializeField]
+	public HitCircle CollisionShape;
+
+	/// <summary>
+	/// User-defined metadata slot reserved for simulation subsystems.
+	/// </summary>
+	[SerializeField]
+	public int CustomData;
+
+	/// <summary>
+	/// Tick index of the most recent deterministic update.
+	/// </summary>
+	[SerializeField]
+	public int LastProcessedTick;
+
+	/// <summary>
+	/// Version counter incremented every time the entity is mutated. Enables rollback validation.
+	/// </summary>
+	[SerializeField]
+	public ulong Version;
+
+	/// <summary>
+	/// Factory helper that creates a clean entity template. Callers may further customize the
+	/// struct before submitting it to <see cref="TheWorld.SpawnEntity"/>.
+	/// </summary>
+	public static EntityData CreateTemplate(FixedVector2 position, HitCircle collision, int teamId = 0)
+	{
+		return new EntityData
+		{
+			Id = EntityId.Invalid,
+			IsActive = false,
+			Position = position,
+			Velocity = new FixedVector2(0, 0),
+			ExternalImpulse = new FixedVector2(0, 0),
+			FacingMilliDegrees = 0,
+			TeamId = teamId,
+			HitPoints = 0,
+			MaxHitPoints = 0,
+			StateFlags = 0,
+			CollisionShape = collision,
+			CustomData = 0,
+			LastProcessedTick = -1,
+			Version = 0
+		};
+	}
+
+	/// <summary>
+	/// Applies deterministic motion for one tick by consuming velocity and impulse.
+	/// </summary>
+	public void IntegrateMotion()
+	{
+		Position = Position + Velocity + ExternalImpulse;
+		ExternalImpulse = new FixedVector2(0, 0);
+	}
+
+	/// <summary>
+	/// Increases or decreases health using fixed raw units. The method clamps values deterministically.
+	/// </summary>
+	public void ApplyDamage(int delta)
+	{
+		int newValue = HitPoints + delta;
+		if (newValue < 0)
+		{
+			newValue = 0;
+		}
+		else if (MaxHitPoints > 0 && newValue > MaxHitPoints)
+		{
+			newValue = MaxHitPoints;
+		}
+		HitPoints = newValue;
+	}
+
+	/// <summary>
+	/// Utility that marks the entity as inactive without returning it to the pool. Used by snapshots.
+	/// </summary>
+	public void Deactivate()
+	{
+		IsActive = false;
+		Version++;
+	}
+}

--- a/Assets/Scripts/Generals/EntityData.cs.meta
+++ b/Assets/Scripts/Generals/EntityData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d8529a9b125942df83639009e7f0570d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Generals/TheWorld.cs
+++ b/Assets/Scripts/Generals/TheWorld.cs
@@ -1,0 +1,317 @@
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// Pure deterministic system contract. Implementations must avoid random generators,
+/// floating point math, or Unity API access to guarantee replay stability.
+/// </summary>
+public interface IWorldSystem
+{
+	string Name { get; }
+	void Execute(TheWorld world);
+}
+
+/// <summary>
+/// Serializable snapshot of the entire world state. Used for rollback, save/load,
+/// or deterministic verification between peers.
+/// </summary>
+[Serializable]
+public struct WorldSnapshot
+{
+	public int Tick;
+	public ulong WorldVersion;
+	public EntityData[] Entities;
+}
+
+/// <summary>
+/// Deterministic container responsible for owning every <see cref="EntityData"/> instance.
+/// The class enforces a strict update order, stable entity identifiers, and snapshot
+/// capabilities that make lockstep or rollback netcode feasible.
+/// </summary>
+[Serializable]
+public sealed class TheWorld
+{
+	[SerializeField] private readonly List<EntityData> _entities = new();
+	[SerializeField] private readonly List<int> _freeIds = new();
+	[NonSerialized] private readonly List<SystemRegistration> _systems = new();
+
+	[SerializeField] private ulong _worldVersion;
+
+	public int CurrentTick { get; private set; }
+	public ulong WorldVersion => _worldVersion;
+	public int ActiveEntityCount { get; private set; }
+
+	/// <summary>
+	/// Optional deterministic random access for the Unity bridge. The list reference must never be mutated externally.
+	/// </summary>
+	public IReadOnlyList<EntityData> Entities => _entities;
+
+	/// <summary>
+	/// Registers a deterministic system that will be executed each tick using the provided order.
+	/// Lower order values run first. Registration is idempotent based on instance reference.
+	/// </summary>
+	public void RegisterSystem(IWorldSystem system, int order)
+	{
+		if (system == null)
+		{
+			throw new ArgumentNullException(nameof(system));
+		}
+
+		for (int i = 0; i < _systems.Count; i++)
+		{
+			if (ReferenceEquals(_systems[i].System, system))
+			{
+				return;
+			}
+		}
+
+		_systems.Add(new SystemRegistration(order, system));
+		_systems.Sort((a, b) => a.Order.CompareTo(b.Order));
+	}
+
+	/// <summary>
+	/// Removes a previously registered system. Useful for deterministic scenario swapping.
+	/// </summary>
+	public bool UnregisterSystem(IWorldSystem system)
+	{
+		if (system == null)
+		{
+			return false;
+		}
+
+		for (int i = 0; i < _systems.Count; i++)
+		{
+			if (!ReferenceEquals(_systems[i].System, system))
+			{
+				continue;
+			}
+			_systems.RemoveAt(i);
+			return true;
+		}
+		return false;
+	}
+
+	/// <summary>
+	/// Spawns an entity by reserving a deterministic identifier and copying the template.
+	/// The caller remains responsible for populating component fields before invoking this method.
+	/// </summary>
+	public EntityId SpawnEntity(EntityData template)
+	{
+		int index;
+                if (_freeIds.Count > 0)
+                {
+                        int last = _freeIds.Count - 1;
+                        index = _freeIds[last];
+                        _freeIds.RemoveAt(last);
+                }
+		else
+		{
+			index = _entities.Count;
+			_entities.Add(default);
+		}
+
+		template.Id = new EntityId(index);
+		template.IsActive = true;
+		template.Version++;
+		template.LastProcessedTick = CurrentTick;
+		_entities[index] = template;
+		ActiveEntityCount++;
+		_worldVersion++;
+		return template.Id;
+	}
+
+	/// <summary>
+	/// Marks an entity as inactive and recycles the identifier for future reuse.
+	/// </summary>
+	public bool DespawnEntity(EntityId id)
+	{
+		if (!TryGetEntity(id, out var entity) || !entity.IsActive)
+		{
+			return false;
+		}
+
+		entity.IsActive = false;
+		entity.Version++;
+		_entities[id.Value] = entity;
+		ActiveEntityCount--;
+		_freeIds.Add(id.Value);
+		_worldVersion++;
+		return true;
+	}
+
+	/// <summary>
+	/// Attempts to fetch a copy of the entity. Use <see cref="WriteEntity"/> to commit mutations.
+	/// </summary>
+	public bool TryGetEntity(EntityId id, out EntityData entity)
+	{
+		if (!id.IsValid || id.Value >= _entities.Count)
+		{
+			entity = default;
+			return false;
+		}
+
+		entity = _entities[id.Value];
+		return entity.IsActive;
+	}
+
+	/// <summary>
+	/// Commits an updated entity struct back into the world buffer. The identifier must remain unchanged.
+	/// </summary>
+	public void WriteEntity(EntityData entity)
+	{
+		if (!entity.Id.IsValid)
+		{
+			throw new ArgumentException("Entity must have a valid identifier before writing.", nameof(entity));
+		}
+		if (entity.Id.Value >= _entities.Count)
+		{
+			throw new IndexOutOfRangeException("Entity identifier exceeds buffer capacity.");
+		}
+		_entities[entity.Id.Value] = entity;
+		_worldVersion++;
+	}
+
+	/// <summary>
+	/// Executes the deterministic tick loop. Order of operations:
+	/// 1) Integrate velocity for every active entity.
+	/// 2) Invoke registered systems in ascending order.
+	/// </summary>
+	public void UpdateWorld()
+	{
+		CurrentTick++;
+
+		for (int i = 0; i < _entities.Count; i++)
+		{
+			var entity = _entities[i];
+			if (!entity.IsActive)
+			{
+				continue;
+			}
+
+			entity.LastProcessedTick = CurrentTick;
+			entity.IntegrateMotion();
+			entity.Version++;
+			_entities[i] = entity;
+		}
+
+		for (int i = 0; i < _systems.Count; i++)
+		{
+			_systems[i].System.Execute(this);
+		}
+
+		_worldVersion++;
+	}
+
+	/// <summary>
+	/// Produces a deep copy snapshot of the world buffer for deterministic rollback.
+	/// </summary>
+	public WorldSnapshot CreateSnapshot()
+	{
+		return new WorldSnapshot
+		{
+			Tick = CurrentTick,
+			WorldVersion = _worldVersion,
+			Entities = _entities.ToArray()
+		};
+	}
+
+	/// <summary>
+	/// Restores world state from a snapshot generated by <see cref="CreateSnapshot"/>.
+	/// </summary>
+	public void ApplySnapshot(WorldSnapshot snapshot)
+	{
+		if (snapshot.Entities == null)
+		{
+			throw new ArgumentException("Snapshot must contain entity data.", nameof(snapshot));
+		}
+
+		_entities.Clear();
+		_entities.AddRange(snapshot.Entities);
+		_freeIds.Clear();
+		for (int i = 0; i < _entities.Count; i++)
+		{
+			if (!_entities[i].IsActive)
+			{
+				_freeIds.Add(i);
+			}
+		}
+
+		CurrentTick = snapshot.Tick;
+		_worldVersion = snapshot.WorldVersion;
+		ActiveEntityCount = CountActiveEntities();
+	}
+
+	/// <summary>
+	/// Returns a deterministic enumeration of active entity identifiers.
+	/// </summary>
+	public IEnumerable<EntityId> EnumerateActiveEntities()
+	{
+		for (int i = 0; i < _entities.Count; i++)
+		{
+			if (_entities[i].IsActive)
+			{
+				yield return new EntityId(i);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Clears all entities and resets counters. Intended for deterministic tests.
+	/// </summary>
+	public void Clear()
+	{
+		_entities.Clear();
+		_freeIds.Clear();
+		ActiveEntityCount = 0;
+		CurrentTick = 0;
+		_worldVersion = 0;
+	}
+
+	/// <summary>
+	/// Unity bridge helper: fetches the latest entity copy for visualization without mutating state.
+	/// </summary>
+	public EntityData PeekEntity(EntityId id)
+	{
+		if (!TryGetEntity(id, out var entity))
+		{
+			throw new KeyNotFoundException($"Entity {id} is not active.");
+		}
+		return entity;
+	}
+
+	/// <summary>
+	/// Calculates the deterministic number of active entities, used when restoring snapshots.
+	/// </summary>
+	private int CountActiveEntities()
+	{
+		int count = 0;
+		for (int i = 0; i < _entities.Count; i++)
+		{
+			if (_entities[i].IsActive)
+			{
+				count++;
+			}
+		}
+		return count;
+	}
+
+	/// <summary>
+	/// Internal record describing a registered deterministic system.
+	/// </summary>
+	[Serializable]
+	private readonly struct SystemRegistration
+	{
+		public readonly int Order;
+		public readonly IWorldSystem System;
+
+		public SystemRegistration(int order, IWorldSystem system)
+		{
+			Order = order;
+			System = system;
+		}
+	}
+
+	/** Optional debug hook: enable to dump the active entity list per tick.
+	public bool VerboseLogging;
+	*/
+}

--- a/Assets/Scripts/Generals/TheWorld.cs.meta
+++ b/Assets/Scripts/Generals/TheWorld.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 97fc4333eb3b4ce4a5262a89f1ffd124
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add a serializable `EntityId`/`EntityData` pair to describe deterministic per-entity state
- introduce `TheWorld` deterministic container with system pipeline, snapshots, and bridge helpers

## Testing
- not run (unity project)


------
https://chatgpt.com/codex/tasks/task_e_68eef5e3902c832c8a90a7ed09331b08