### PR TITLE
Refactor EntityId to ushort-backed handles

### DIFF
--- a/Assets/Scripts/Systems/EntityData.cs
+++ b/Assets/Scripts/Systems/EntityData.cs
@@ -11,9 +11,10 @@ using UnityEngine;
 public readonly struct EntityId : IEquatable<EntityId>, IComparable<EntityId>
 {
 	/// <summary>
-	/// Sentinel value representing an invalid or unassigned entity reference.
-	/// </summary>
-	public static readonly EntityId Invalid = new(0);
+        /// Sentinel value representing an invalid or unassigned entity reference.
+        /// This maps to index 0 so that default(EntityId) is also treated as invalid.
+        /// </summary>
+        public static readonly EntityId Invalid = new(0);
 
 	[SerializeField]
 	private readonly ushort _value;
@@ -25,11 +26,39 @@ public readonly struct EntityId : IEquatable<EntityId>, IComparable<EntityId>
 	}
 
 	/// <summary>
-	/// Raw integer handle used for deterministic array indexing. Intended for serialization only.
-	/// </summary>
-	public ushort Value => _value;
+        /// Raw identifier stored as a 1-based index for deterministic array access. Intended for serialization only.
+        /// </summary>
+        public ushort Value => _value;
 
-	public bool IsValid => _value > 0;
+        public bool IsValid => _value > 0;
+
+        /// <summary>
+        /// Converts the identifier into the zero-based index used by the world buffers.
+        /// Throws if invoked on an invalid identifier to avoid silent underflow.
+        /// </summary>
+        public int ToIndex()
+        {
+                if (!IsValid)
+                {
+                        throw new InvalidOperationException("Cannot convert an invalid EntityId to an index.");
+                }
+
+                return _value - 1;
+        }
+
+        /// <summary>
+        /// Factory helper that converts a zero-based buffer index into an <see cref="EntityId"/>.
+        /// Ensures we never overflow the ushort range when assigning identifiers.
+        /// </summary>
+        public static EntityId FromIndex(int index)
+        {
+                if (index < 0 || index >= ushort.MaxValue)
+                {
+                        throw new ArgumentOutOfRangeException(nameof(index), index, "Entity index must map into the ushort range.");
+                }
+
+                return new EntityId((ushort)(index + 1));
+        }
 
 	public bool Equals(EntityId other)
 	{

--- a/Assets/Scripts/Systems/TheWorld.cs
+++ b/Assets/Scripts/Systems/TheWorld.cs
@@ -48,8 +48,8 @@ public struct WorldSnapshot
 [Serializable]
 public sealed class TheWorld
 {
-	private readonly List<EntityData> _entities = new();
-	private readonly List<int> _freeIds = new();
+        private readonly List<EntityData> _entities = new();
+        private readonly List<int> _freeIds = new();
 	[NonSerialized] private readonly List<SystemRegistration> _systems = new();
 	[SerializeField] private ulong worldVersion;
 
@@ -127,25 +127,30 @@ public sealed class TheWorld
 	/// </summary>
 	public EntityId SpawnEntity(EntityData template)
 	{
-		int index;
+                int index;
                 if (_freeIds.Count > 0)
                 {
                         int last = _freeIds.Count - 1;
                         index = _freeIds[last];
                         _freeIds.RemoveAt(last);
                 }
-		else
-		{
-			index = _entities.Count;
-			_entities.Add(default);
-		}
+                else
+                {
+                        index = _entities.Count;
+                        if (index >= ushort.MaxValue)
+                        {
+                                // Guard against overflowing the ushort-backed EntityId range.
+                                throw new InvalidOperationException("Entity capacity exceeded: cannot allocate more than ushort.MaxValue entries.");
+                        }
+                        _entities.Add(default);
+                }
 
-		template.Id = new EntityId(index);
-		template.IsActive = true;
-		template.Version++;
-		template.LastProcessedTick = CurrentTick;
-		_entities[index] = template;
-		ActiveEntityCount++;
+                template.Id = EntityId.FromIndex(index);
+                template.IsActive = true;
+                template.Version++;
+                template.LastProcessedTick = CurrentTick;
+                _entities[index] = template;
+                ActiveEntityCount++;
 		worldVersion++;
 		return template.Id;
 	}
@@ -155,51 +160,60 @@ public sealed class TheWorld
 	/// </summary>
 	public bool DespawnEntity(EntityId id)
 	{
-		if (!TryGetEntity(id, out var entity) || !entity.IsActive)
-		{
-			return false;
-		}
+                if (!TryGetEntity(id, out var entity) || !entity.IsActive)
+                {
+                        return false;
+                }
 
-		entity.IsActive = false;
-		entity.Version++;
-		_entities[id.Value] = entity;
-		ActiveEntityCount--;
-		_freeIds.Add(id.Value);
-		worldVersion++;
-		return true;
-	}
+                entity.IsActive = false;
+                entity.Version++;
+                int index = id.ToIndex();
+                _entities[index] = entity;
+                ActiveEntityCount--;
+                _freeIds.Add(index);
+                worldVersion++;
+                return true;
+        }
 
 	/// <summary>
 	/// Attempts to fetch a copy of the entity. Use <see cref="WriteEntity"/> to commit mutations.
 	/// </summary>
 	public bool TryGetEntity(EntityId id, out EntityData entity)
 	{
-		if (!id.IsValid || id.Value >= _entities.Count)
-		{
-			entity = default;
-			return false;
-		}
+                if (!id.IsValid)
+                {
+                        entity = default;
+                        return false;
+                }
 
-		entity = _entities[id.Value];
-		return entity.IsActive;
-	}
+                int index = id.ToIndex();
+                if ((uint)index >= (uint)_entities.Count)
+                {
+                        entity = default;
+                        return false;
+                }
+
+                entity = _entities[index];
+                return entity.IsActive;
+        }
 
 	/// <summary>
 	/// Commits an updated entity struct back into the world buffer. The identifier must remain unchanged.
 	/// </summary>
 	public void WriteEntity(EntityData entity)
 	{
-		if (!entity.Id.IsValid)
-		{
-			throw new ArgumentException("Entity must have a valid identifier before writing.", nameof(entity));
-		}
-		if (entity.Id.Value >= _entities.Count)
-		{
-			throw new IndexOutOfRangeException("Entity identifier exceeds buffer capacity.");
-		}
-		_entities[entity.Id.Value] = entity;
-		worldVersion++;
-	}
+                if (!entity.Id.IsValid)
+                {
+                        throw new ArgumentException("Entity must have a valid identifier before writing.", nameof(entity));
+                }
+                int index = entity.Id.ToIndex();
+                if ((uint)index >= (uint)_entities.Count)
+                {
+                        throw new IndexOutOfRangeException("Entity identifier exceeds buffer capacity.");
+                }
+                _entities[index] = entity;
+                worldVersion++;
+        }
 
 	/// <summary>
 	/// Executes the deterministic tick loop. Order of operations:
@@ -210,9 +224,9 @@ public sealed class TheWorld
 	{
 		CurrentTick++;
 
-		for (int i = 0; i < _entities.Count; i++)
-		{
-			var entity = _entities[i];
+                for (int i = 0; i < _entities.Count; i++)
+                {
+                        var entity = _entities[i];
 			if (!entity.IsActive)
 			{
 				continue;
@@ -276,13 +290,13 @@ public sealed class TheWorld
 	/// </summary>
 	public IEnumerable<EntityId> EnumerateActiveEntities()
 	{
-		for (int i = 0; i < _entities.Count; i++)
-		{
-			if (_entities[i].IsActive)
-			{
-				yield return new EntityId(i);
-			}
-		}
+                for (int i = 0; i < _entities.Count; i++)
+                {
+                        if (_entities[i].IsActive)
+                        {
+                                yield return EntityId.FromIndex(i);
+                        }
+                }
 	}
 
 	/// <summary>


### PR DESCRIPTION
## Summary
- add explicit conversion helpers on EntityId to map between ushort handles and zero-based indices
- update TheWorld to allocate identifiers with EntityId.FromIndex and guard against overflow
- ensure entity lifecycle methods reuse freed slots through the new ushort-safe conversions

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68f05be39f24832c9d9f4822c81cf411