### PR TITLE
Add entity creation API to TheWorld

### DIFF
--- a/Assets/Scripts/Systems/EntityWorld/EntityData.cs
+++ b/Assets/Scripts/Systems/EntityWorld/EntityData.cs
@@ -118,6 +118,14 @@ public struct EntityData
 	/// </summary>
 	[SerializeField]
 	public bool isActive;
+
+	/// <summary>
+	/// High-level classification used by systems that need to filter by archetype.
+	/// This remains under <see cref="TheWorld"/>'s control so that entity ownership
+	/// is centralized and deterministic.
+	/// </summary>
+	[SerializeField]
+	public EntityType entityType;
 	
 	/// <summary>
 	/// World-space position expressed in fixed units.
@@ -202,6 +210,7 @@ public struct EntityData
 		{
 			id = EntityId.Invalid, //?
 			isActive = false,
+			entityType = EntityType.None,
 			transform = position,
 			velocity = new FixedVector2(0, 0),
 			externalImpulse = new FixedVector2(0, 0),

--- a/Assets/Scripts/Systems/EntityWorld/TheWorld.cs
+++ b/Assets/Scripts/Systems/EntityWorld/TheWorld.cs
@@ -55,6 +55,13 @@ public sealed class TheWorld
 	[NonSerialized] private readonly List<SystemRegistration> _systems = new();
 	[SerializeField] private ulong worldVersion;
 
+	/// <summary>
+	/// Delegate used to customize freshly created entities before they are spawned.
+	/// Keeping this callback deterministic allows callers to inject additional data
+	/// without bypassing <see cref="TheWorld"/>'s ownership guarantees.
+	/// </summary>
+	public delegate void EntityConfigurator(ref EntityData entityData);
+
 	public TheWorld()
 	{
 		Initialize();
@@ -122,6 +129,36 @@ public sealed class TheWorld
 		}
 		return false;
 	}
+
+	/// <summary>
+	/// Creates a new entity in a deterministic fashion and registers it with the world.
+	/// Internally, this method leverages the <see cref="EntityData.CreateTemplate"/> helper
+	/// to guarantee that every entity starts from the same zeroed baseline. Callers may
+	/// optionally provide a configurator to fill in gameplay-specific fields before the
+	/// entity is spawned.
+	/// </summary>
+	/// <param name="entityType">High-level classification for downstream systems.</param>
+	/// <param name="position">Initial world transform expressed in fixed units.</param>
+	/// <param name="collisionShape">Deterministic collision primitive assigned to the entity.</param>
+	/// <param name="teamId">Owning team; defaults to the player's side for convenience.</param>
+	/// <param name="configurator">Optional deterministic callback for additional initialization.</param>
+	/// <returns>The <see cref="EntityId"/> assigned by the world.</returns>
+	public EntityId CreateEntity(
+		EntityType entityType,
+		FixedVector2 position,
+		HitCircle collisionShape,
+		Team teamId = Team.Me,
+		EntityConfigurator configurator = null)
+	{
+		var entity = EntityData.CreateTemplate(position, collisionShape, teamId);
+		entity.entityType = entityType;
+
+		configurator?.Invoke(ref entity);
+
+		// Delegate to SpawnEntity so that identifier allocation remains centralized.
+		return SpawnEntity(entity);
+	}
+	/** Future extension: expose overloads that accept prefab-like blueprints for richer authoring. */
 
 	/// <summary>
 	/// Spawns an entity by reserving a deterministic identifier and copying the template.


### PR DESCRIPTION
## Summary
- add an `EntityConfigurator` delegate and a high-level `CreateEntity` helper to `TheWorld`
- persist the entity type on `EntityData` templates so the world can classify new instances

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68f6db95398c832ca068459b96f9c237